### PR TITLE
Feature(#4): Google API와 연동해 프로필 정보 불러오기

### DIFF
--- a/server/src/main/java/com/yeohaeng_ttukttak/server/ServerApplication.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/ServerApplication.java
@@ -1,6 +1,6 @@
 package com.yeohaeng_ttukttak.server;
 
-import com.yeohaeng_ttukttak.server.user.client.GoogleOAuthProperties;
+import com.yeohaeng_ttukttak.server.user.service.client.property.GoogleOAuthProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/config/HttpInterfaceConfig.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/config/HttpInterfaceConfig.java
@@ -1,7 +1,8 @@
 package com.yeohaeng_ttukttak.server.common.config;
 
 import com.yeohaeng_ttukttak.server.common.util.MyStringUtil;
-import com.yeohaeng_ttukttak.server.user.client.GoogleOAuthClient;
+import com.yeohaeng_ttukttak.server.user.service.client.GoogleOAuthClient;
+import com.yeohaeng_ttukttak.server.user.service.client.GoogleProfileClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -63,6 +64,14 @@ public class HttpInterfaceConfig {
 
         return httpServiceProxyFactory
                 .createClient(GoogleOAuthClient.class);
+
+    }
+
+    @Bean
+    public GoogleProfileClient googleProfileClient(
+            HttpServiceProxyFactory httpServiceProxyFactory) {
+
+        return httpServiceProxyFactory.createClient(GoogleProfileClient.class);
 
     }
 

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/config/HttpInterfaceConfig.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/config/HttpInterfaceConfig.java
@@ -31,6 +31,12 @@ public class HttpInterfaceConfig {
                             new InputStreamReader(response.getBody()))) {
 
                         log.error("[{}] >> {} {}", shortUUID, request.getMethod(), request.getURI());
+
+                        request.getHeaders()
+                                .forEach((key, values) -> {
+                                    log.error("[{}] >> -- {}: {}", shortUUID, key, values);
+                                });
+
                         log.error("[{}] << {}", shortUUID, response.getStatusCode());
 
                         String line;

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/controller/dto/UserController.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/controller/dto/UserController.java
@@ -1,0 +1,25 @@
+package com.yeohaeng_ttukttak.server.user.controller.dto;
+
+import com.yeohaeng_ttukttak.server.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v2/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/sign-up")
+    public void signUp(@RequestParam String code) {
+        log.info("code={}", code);
+        userService.signUp(code);
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/UserService.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/UserService.java
@@ -1,0 +1,37 @@
+package com.yeohaeng_ttukttak.server.user.service;
+
+import com.yeohaeng_ttukttak.server.user.service.client.GoogleOAuthClient;
+import com.yeohaeng_ttukttak.server.user.service.client.property.GoogleOAuthProperties;
+import com.yeohaeng_ttukttak.server.user.service.client.GoogleProfileClient;
+import com.yeohaeng_ttukttak.server.user.service.client.dto.ExchangeTokenRequest;
+import com.yeohaeng_ttukttak.server.user.service.client.dto.ExchangeTokenResponse;
+import com.yeohaeng_ttukttak.server.user.service.client.dto.GetProfileResponse;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class UserService {
+
+    private final GoogleOAuthProperties oauthClient;
+    private final GoogleOAuthClient googleOAuthClient;
+
+    private final GoogleProfileClient googleProfileClient;
+
+    public void signUp(String code) {
+
+        ExchangeTokenRequest tokenRequest = new ExchangeTokenRequest(oauthClient, code);
+        ExchangeTokenResponse tokenResponse = googleOAuthClient.exchangeToken(tokenRequest);
+
+        log.info("response={}", tokenResponse);
+
+        String authHeader = "Bearer " + tokenResponse.accessToken();
+        GetProfileResponse profileResponse = googleProfileClient.getProfile(authHeader);
+
+        log.info("profile={}", profileResponse);
+
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/GoogleOAuthClient.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/GoogleOAuthClient.java
@@ -1,7 +1,7 @@
-package com.yeohaeng_ttukttak.server.user.client;
+package com.yeohaeng_ttukttak.server.user.service.client;
 
-import com.yeohaeng_ttukttak.server.user.client.dto.ExchangeTokenRequest;
-import com.yeohaeng_ttukttak.server.user.client.dto.ExchangeTokenResponse;
+import com.yeohaeng_ttukttak.server.user.service.client.dto.ExchangeTokenRequest;
+import com.yeohaeng_ttukttak.server.user.service.client.dto.ExchangeTokenResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.service.annotation.HttpExchange;

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/GoogleProfileClient.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/GoogleProfileClient.java
@@ -1,0 +1,21 @@
+package com.yeohaeng_ttukttak.server.user.service.client;
+
+import com.yeohaeng_ttukttak.server.user.service.client.dto.GetProfileResponse;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+
+@Component
+@HttpExchange("https://people.googleapis.com/v1")
+public interface GoogleProfileClient {
+
+    @GetExchange("/people/me?personFields=birthdays,genders")
+    GetProfileResponse getProfile(
+            @RequestHeader(name = "Authorization")
+            String authorization);
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/dto/ExchangeTokenRequest.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/dto/ExchangeTokenRequest.java
@@ -1,7 +1,7 @@
-package com.yeohaeng_ttukttak.server.user.client.dto;
+package com.yeohaeng_ttukttak.server.user.service.client.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.yeohaeng_ttukttak.server.user.client.GoogleOAuthProperties;
+import com.yeohaeng_ttukttak.server.user.service.client.property.GoogleOAuthProperties;
 
 public record ExchangeTokenRequest (
         String code,

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/dto/ExchangeTokenResponse.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/dto/ExchangeTokenResponse.java
@@ -1,4 +1,4 @@
-package com.yeohaeng_ttukttak.server.user.client.dto;
+package com.yeohaeng_ttukttak.server.user.service.client.dto;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/dto/GetProfileResponse.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/dto/GetProfileResponse.java
@@ -1,0 +1,13 @@
+package com.yeohaeng_ttukttak.server.user.service.client.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.yeohaeng_ttukttak.server.user.service.client.dto.deserializer.GoogleGetProfileResponseDeserializer;
+import com.yeohaeng_ttukttak.server.user.domain.Gender;
+
+import java.time.LocalDate;
+
+@JsonDeserialize(using = GoogleGetProfileResponseDeserializer.class)
+public record GetProfileResponse (
+        LocalDate birthday,
+        Gender gender
+) { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/dto/deserializer/GoogleGetProfileResponseDeserializer.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/dto/deserializer/GoogleGetProfileResponseDeserializer.java
@@ -1,0 +1,66 @@
+package com.yeohaeng_ttukttak.server.user.service.client.dto.deserializer;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.yeohaeng_ttukttak.server.user.service.client.dto.GetProfileResponse;
+import com.yeohaeng_ttukttak.server.user.domain.Gender;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Slf4j
+public class GoogleGetProfileResponseDeserializer extends JsonDeserializer<GetProfileResponse> {
+
+    @Override
+    public GetProfileResponse deserialize(
+            JsonParser parser, DeserializationContext ctxt) throws IOException, JacksonException {
+
+        final JsonNode rootNode = parser.getCodec().readTree(parser);
+
+        LocalDate birthday = Optional
+                .ofNullable(rootNode.findValue("birthdays"))
+                .map(node -> node.findValue("date"))
+                .map(this::parseDateNode)
+                .orElse(null);
+
+        String value = Optional
+                .ofNullable(rootNode.findValue("genders"))
+                .map(node -> node.findValue("value"))
+                .map(node -> node.asText().toUpperCase())
+                .orElse("NONE");
+
+        Gender gender;
+
+        try {
+            gender = Gender.valueOf(value);
+        } catch (IllegalArgumentException ex) {
+            gender = Gender.NONE;
+        }
+
+        return new GetProfileResponse(birthday, gender);
+    }
+
+
+    private LocalDate parseDateNode(JsonNode dateNode) {
+
+        if (dateNode == null) return null;
+
+        int year = dateNode.get("year").asInt(0);
+        int month = dateNode.get("month").asInt(0);
+        int day = dateNode.get("day").asInt(0);
+
+        try {
+            return LocalDate.of(year, month, day);
+        } catch (DateTimeException ex) {
+            return null;
+        }
+
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/property/GoogleOAuthProperties.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/property/GoogleOAuthProperties.java
@@ -1,4 +1,4 @@
-package com.yeohaeng_ttukttak.server.user.client;
+package com.yeohaeng_ttukttak.server.user.service.client.property;
 
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -14,7 +14,6 @@ spring:
     activate.on-profile: dev
     import: aws-parameterstore:/yeohaeng-ttukttak/server_dev/
 
-
 management:
   server.port: 8081
 
@@ -29,6 +28,6 @@ oauth:
   google:
     client-id: 951324022006-eigc5h6tj71rm2v31eqr5u0v07cbmpn1.apps.googleusercontent.com
     client-secret: ${GoogleOAuthProperties}
-    scope: https://www.googleapis.com/auth/user.gender.read https://www.googleapis.com/auth/user.birthday.read
+    scope: https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/user.gender.read https://www.googleapis.com/auth/user.birthday.read
     redirect-uri: https://dev.yeohaeng-ttukttak.com/api/v2/users/sign-up
     grant-type: authorization_code

--- a/server/src/test/java/com/yeohaeng_ttukttak/server/user/service/client/dto/deserializer/GoogleGetProfileResponseDeserializerTest.java
+++ b/server/src/test/java/com/yeohaeng_ttukttak/server/user/service/client/dto/deserializer/GoogleGetProfileResponseDeserializerTest.java
@@ -1,0 +1,221 @@
+package com.yeohaeng_ttukttak.server.user.service.client.dto.deserializer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yeohaeng_ttukttak.server.user.service.client.dto.GetProfileResponse;
+import com.yeohaeng_ttukttak.server.user.domain.Gender;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+class GoogleGetProfileResponseDeserializerTest {
+
+    @Test
+    void deserialize_test() throws JsonProcessingException {
+
+        // GIVEN
+        String jsonString = """
+        {
+            "resourceName": "people/7483916205841930264712",
+            "etag": "A7dK9tL1mQ4pW8rZ3vX2bC0sF6nYj5oHkU7",
+            "genders": [
+                {
+                    "metadata": {
+                        "primary": true,
+                        "source": {
+                            "type": "PROFILE",
+                            "id": "7483916205841930264712"
+                        }
+                    },
+                    "value": "male",
+                    "formattedValue": "Male"
+                }
+            ],
+            "birthdays": [
+                {
+                    "metadata": {
+                        "primary": true,
+                        "source": {
+                            "type": "ACCOUNT",
+                            "id": "7483916205841930264712"
+                        }
+                    },
+                    "date": {
+                        "year": 1998,
+                        "month": 11,
+                        "day": 17
+                    }
+                }
+            ]
+        }
+        """;
+
+        // WHEN
+        GetProfileResponse profileResponse = new ObjectMapper()
+                .readValue(jsonString, GetProfileResponse.class);
+
+        // THEN
+        assertThat(profileResponse.birthday())
+                .isEqualTo(LocalDate.of(1998, 11, 17));
+
+        assertThat(profileResponse.gender()).isEqualTo(Gender.MALE);
+
+    }
+
+    @Test
+    void deserialize_null_test() throws JsonProcessingException {
+
+        // GIVEN
+        String jsonString = """
+        {
+            "resourceName": "people/7483916205841930264712",
+            "etag": "A7dK9tL1mQ4pW8rZ3vX2bC0sF6nYj5oHkU7",
+            "genders": [],
+            "birthdays": []
+        }
+        """;
+
+        // WHEN
+        GetProfileResponse profileResponse = new ObjectMapper()
+                .readValue(jsonString, GetProfileResponse.class);
+
+        // THEN
+        assertThat(profileResponse.birthday()).isNull();
+        assertThat(profileResponse.gender()).isEqualTo(Gender.NONE);
+
+    }
+
+    @Test
+    void deserialize_other_value_test() throws JsonProcessingException {
+
+        // GIVEN
+        String jsonString = """
+        {
+            "resourceName": "people/7483916205841930264712",
+            "etag": "A7dK9tL1mQ4pW8rZ3vX2bC0sF6nYj5oHkU7",
+            "genders": [
+                {
+                    "metadata": {
+                        "primary": true,
+                        "source": {
+                            "type": "PROFILE",
+                            "id": "7483916205841930264712"
+                        }
+                    },
+                    "value": "unspecified",
+                    "formattedValue": "Unspecified"
+                }
+            ],
+            "birthdays": []
+        }
+        """;
+
+        // WHEN
+        GetProfileResponse profileResponse = new ObjectMapper()
+                .readValue(jsonString, GetProfileResponse.class);
+
+        // THEN
+        assertThat(profileResponse.birthday()).isNull();
+        assertThat(profileResponse.gender()).isEqualTo(Gender.NONE);
+
+    }
+
+    @Test
+    void deserialize_multiple_value_test() throws JsonProcessingException {
+        String jsonString = """
+        {
+            "resourceName": "people/7483916205841930264712",
+            "etag": "A7dK9tL1mQ4pW8rZ3vX2bC0sF6nYj5oHkU7",
+            "genders": [
+                {
+                    "metadata": {
+                        "primary": true,
+                        "source": {
+                            "type": "PROFILE",
+                            "id": "7483916205841930264712"
+                        }
+                    },
+                    "value": "male",
+                    "formattedValue": "Male"
+                },
+                {
+                    "metadata": {
+                        "primary": true,
+                        "source": {
+                            "type": "PROFILE",
+                            "id": "7483916205841930264712"
+                        }
+                    },
+                    "value": "female",
+                    "formattedValue": "Female"
+                }
+            ],
+            "birthdays": [
+                {
+                    "metadata": {
+                        "primary": true,
+                        "source": {
+                            "type": "ACCOUNT",
+                            "id": "7483916205841930264712"
+                        }
+                    },
+                    "date": {
+                        "year": 1998,
+                        "month": 11,
+                        "day": 17
+                    }
+                },
+                {
+                    "metadata": {
+                        "primary": true,
+                        "source": {
+                            "type": "ACCOUNT",
+                            "id": "7483916205841930264712"
+                        }
+                    },
+                    "date": {
+                        "year": 1998,
+                        "month": 11,
+                        "day": 18
+                    }
+                }
+            ]
+        }
+        """;
+
+        // WHEN
+        GetProfileResponse profileResponse = new ObjectMapper()
+                .readValue(jsonString, GetProfileResponse.class);
+
+        // THEN
+        assertThat(profileResponse.birthday())
+                .isEqualTo(LocalDate.of(1998, 11, 17));
+
+        assertThat(profileResponse.gender()).isEqualTo(Gender.MALE);
+    }
+
+    @Test
+    void deserialize_no_key_test() throws JsonProcessingException {
+
+        String jsonString = """
+        {
+            "resourceName": "people/7483916205841930264712",
+            "etag": "A7dK9tL1mQ4pW8rZ3vX2bC0sF6nYj5oHkU7"
+        }
+        """;
+
+        // WHEN
+        GetProfileResponse profileResponse = new ObjectMapper()
+                .readValue(jsonString, GetProfileResponse.class);
+
+        // THEN
+        assertThat(profileResponse.birthday()).isNull();
+        assertThat(profileResponse.gender()).isEqualTo(Gender.NONE);
+
+    }
+
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> Ex. close #이슈 번호, #이슈 번호

#4 

## 📝 작업 내용
> 작업한 내용을 간략히 설명해 주세요.

- [x] RestClient 에러 핸들러 개선
  - [x] 요청의 헤더 정보 추가

- [x]  Google API 연동해 프로필 정보 불러오기
  - [x] `GooleOauthClient` 작성
  - [x] 복잡한 응답을 추상화하기 위해 Custom Deserializer 구현  

## ✅ 작업 결과
> 작업 내용 Notion 링크, 혹은 이미지를 첨부해 주세요.

### RestClient 에러 핸들러 개선

![image](https://github.com/user-attachments/assets/51ba5264-33c2-4744-9290-05098c158593)

구글 API 테스트 중 인증 헤더를 확인하기 위해 `Header` 정보를 넣었습니다.


## 💬 추가 사항 (선택)
> 추가로 기재할 사항이 있으면 기재해 주세요.

