### PR TITLE
Feature(#4): JWT 유틸 & Google API 인증 인터셉터

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+	implementation 'com.auth0:java-jwt:4.4.0'
+
 	implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.0")
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store'
 

--- a/server/script/deploy_dev.sh
+++ b/server/script/deploy_dev.sh
@@ -21,7 +21,7 @@ scp "$JAR_PATH" bastion:"$DEPLOY_PATH"
 printf "\n\n"
 
 echo "[$DEPLOY_ID] 새로운 서버 배포를 시작합니다."
-ssh bastion "bash -s" < "$SCRIPT_PATH"/launch_application.sh "$DEPLOY_ID"
+ssh bastion "bash -s" < "$SCRIPT_PATH"/launch_application.sh "$DEPLOY_ID" dev
 printf "\n\n"
 
 echo "[$DEPLOY_ID] 성공적으로 배포가 완료되었습니다."

--- a/server/script/launch_application.sh
+++ b/server/script/launch_application.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 DEPLOY_ID=$1
+DEPLOY_PROFILE=$2
 
 if [ -z "$DEPLOY_ID" ]; then
-		echo "[!] 배포 ID가 없습니다. 프로세스를 종료합니다."
+		echo "  [!] 배포 ID가 없습니다. 프로세스를 종료합니다."
 		exit
+fi
+
+if [ -z "$DEPLOY_PROFILE" ]; then
+    echo "  [!] 배포 프로파일이 지정되지 않아 기본값을 할당합니다."
+    echo "    - DEPLOY_PROFILE: prod"
 fi
 
 echo "> 배포 시작 [배포 ID: $DEPLOY_ID]"
@@ -11,16 +17,16 @@ echo "> 배포 시작 [배포 ID: $DEPLOY_ID]"
 CURRENT_PID=$(pgrep -f .jar)
 
 if [ -n "$CURRENT_PID" ]; then
-		echo "> 현재 서버[PID:$CURRENT_PID] 가 실행 중입니다."
+		echo "  > 현재 서버[PID:$CURRENT_PID] 가 실행 중입니다."
 		kill -9 "$CURRENT_PID"
-		echo "> 서버 프로세스[PID:$CURRENT_PID]를 성공적으로 종료했습니다."
+		echo "  > 서버 프로세스[PID:$CURRENT_PID]를 성공적으로 종료했습니다."
 fi
 
 DEPLOY_PATH="deploy/$DEPLOY_ID"
 JAR_PATH=$(ls -tr "$DEPLOY_PATH"/*.jar | tail -n 1)
-echo "> 새 애플리케이션을 배포합니다. [JAR: $JAR_PATH]"
+echo "  > 새 애플리케이션을 배포합니다. [JAR: $JAR_PATH]"
 
 mkdir -p "$DEPLOY_PATH"/log
 
-nohup java -jar "$JAR_PATH" --logging.file.name="$DEPLOY_PATH/log/application.log" >> "$DEPLOY_PATH/log/deploy.log" 2> "$DEPLOY_PATH/log/deploy_error.log" &
-echo "> 새로운 서버 배포가 완료되었습니다."
+nohup java -jar "$JAR_PATH" --spring.profiles.active="$DEPLOY_PROFILE" --logging.file.name="$DEPLOY_PATH/log/application.log" >> "$DEPLOY_PATH/log/deploy.log" 2> "$DEPLOY_PATH/log/deploy_error.log" &
+echo "  > 새로운 서버 배포가 완료되었습니다."

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/config/HttpInterfaceConfig.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/config/HttpInterfaceConfig.java
@@ -1,12 +1,17 @@
 package com.yeohaeng_ttukttak.server.common.config;
 
-import com.yeohaeng_ttukttak.server.common.util.MyStringUtil;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yeohaeng_ttukttak.server.common.util.StringUtil;
 import com.yeohaeng_ttukttak.server.user.service.client.GoogleOAuthClient;
 import com.yeohaeng_ttukttak.server.user.service.client.GoogleProfileClient;
+import com.yeohaeng_ttukttak.server.user.service.client.dto.ExchangeTokenResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.support.RestClientAdapter;
 import org.springframework.web.service.invoker.HttpServiceProxyFactory;
@@ -14,19 +19,21 @@ import org.springframework.web.service.invoker.HttpServiceProxyFactory;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 @Slf4j
 @Configuration
 public class HttpInterfaceConfig {
 
     @Bean
-    public HttpServiceProxyFactory httpServiceProxyFactory() {
+    public RestClient restClient(HttpServletRequest servletRequest) {
 
-        RestClient client = RestClient
-                .builder()
+        return RestClient.builder()
                 .defaultStatusHandler(HttpStatusCode::isError, (request, response) -> {
 
-                    String shortUUID = MyStringUtil.generateShortUUID();
+                    String shortUUID = StringUtil.generateShortUUID();
 
                     try (BufferedReader bodyReader = new BufferedReader(
                             new InputStreamReader(response.getBody()))) {
@@ -50,30 +57,59 @@ public class HttpInterfaceConfig {
                     }
 
                 })
-                .build();
 
-        return HttpServiceProxyFactory
-                .builderFor(RestClientAdapter.create(client))
-                .build();
+                .requestInterceptor(((request, body, execution) -> {
+
+                    Optional.ofNullable(servletRequest.getAttribute("googleAccessToken"))
+                            .ifPresent(accessToken -> {
+
+                                request.getHeaders()
+                                        .add("Authorization", "Bearer " + accessToken);
+
+                            });
+
+                    ClientHttpResponse response =
+                            new ReusableClientHttpResponseWrapper(execution.execute(request, body));
+
+                    String path = request.getURI().getPath();
+
+                    if (!Objects.equals(path, "/token") || !request.getMethod().matches("POST")) {
+                        return response;
+                    }
+
+                    if (response.getStatusCode().isError()) return response;
+
+                    ExchangeTokenResponse tokenResponse = new ObjectMapper()
+                            .readValue(response.getBody(), ExchangeTokenResponse.class);
+
+                    log.info(tokenResponse.accessToken());
+
+                    servletRequest.setAttribute("googleAccessToken", tokenResponse.accessToken());
+
+                    return response;
+
+                })).build();
 
     }
 
     @Bean
-    public GoogleOAuthClient googleOAuthService(
-            HttpServiceProxyFactory httpServiceProxyFactory) {
+    public GoogleOAuthClient googleOAuthService(RestClient googleClient) {
 
-        return httpServiceProxyFactory
+        return HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(googleClient))
+                .build()
                 .createClient(GoogleOAuthClient.class);
 
     }
 
     @Bean
-    public GoogleProfileClient googleProfileClient(
-            HttpServiceProxyFactory httpServiceProxyFactory) {
+    public GoogleProfileClient googleProfileClient(RestClient googleClient) {
 
-        return httpServiceProxyFactory.createClient(GoogleProfileClient.class);
+        return HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(googleClient))
+                .build()
+                .createClient(GoogleProfileClient.class);
 
     }
-
 
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/config/ReusableClientHttpResponseWrapper.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/config/ReusableClientHttpResponseWrapper.java
@@ -1,0 +1,45 @@
+package com.yeohaeng_ttukttak.server.common.config;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
+
+public class ReusableClientHttpResponseWrapper implements ClientHttpResponse {
+
+    private final ClientHttpResponse response;
+    private byte[] body;
+
+    public ReusableClientHttpResponseWrapper(ClientHttpResponse response) throws IOException {
+        this.response = response;
+        this.body = response.getBody().readAllBytes(); // 응답 바디를 바이트 배열로 읽어들임
+    }
+
+    @Override
+    public InputStream getBody() throws IOException {
+        return new ByteArrayInputStream(body); // 바디를 다시 읽을 수 있도록 ByteArrayInputStream으로 반환
+    }
+
+    @Override
+    public HttpHeaders getHeaders() {
+        return response.getHeaders();
+    }
+
+    @Override
+    public HttpStatusCode getStatusCode() throws IOException {
+        return response.getStatusCode();
+    }
+
+    @Override
+    public String getStatusText() throws IOException {
+        return response.getStatusText();
+    }
+
+    @Override
+    public void close() {
+        response.close();
+    }
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/MyStringUtil.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/MyStringUtil.java
@@ -1,5 +1,7 @@
 package com.yeohaeng_ttukttak.server.common.util;
 
+import java.util.Base64;
+
 import static java.util.UUID.randomUUID;
 
 public class MyStringUtil {
@@ -11,5 +13,18 @@ public class MyStringUtil {
                 .substring(0, 8);
 
     }
+
+    public static String toBase64Url(byte[] bytes) {
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(bytes);
+    }
+
+    public static String fromBase64Url(String string) {
+
+        return new String(Base64.getUrlDecoder().decode(string));
+
+    }
+
 
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/StringUtil.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/StringUtil.java
@@ -4,7 +4,7 @@ import java.util.Base64;
 
 import static java.util.UUID.randomUUID;
 
-public class MyStringUtil {
+public class StringUtil {
 
     public static String generateShortUUID() {
 
@@ -21,9 +21,7 @@ public class MyStringUtil {
     }
 
     public static String fromBase64Url(String string) {
-
         return new String(Base64.getUrlDecoder().decode(string));
-
     }
 
 

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/my_jwt/MyJwtClaimBuilder.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/my_jwt/MyJwtClaimBuilder.java
@@ -1,0 +1,47 @@
+package com.yeohaeng_ttukttak.server.common.util.my_jwt;
+
+
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@RequiredArgsConstructor(access = PRIVATE)
+public class MyJwtClaimBuilder {
+
+    private final Map<String, Object> claims = new HashMap<>();
+
+    private String issuer = "yeohaeng-ttukttak.com";
+    private LocalDateTime issuedAt = LocalDateTime.now();
+    private final LocalDateTime expiredAt;
+
+    public static MyJwtClaimBuilder create(LocalDateTime expiredAt) {
+        return new MyJwtClaimBuilder(expiredAt);
+    }
+
+    public MyJwtClaimBuilder addClaim(String key, Object value) {
+        claims.put(key, value);
+        return this;
+    }
+
+    public MyJwtClaimBuilder issuer(String issuer) {
+        this.issuer = issuer;
+        return this;
+    }
+
+    public MyJwtClaimBuilder issuedAt(LocalDateTime issuedAt) {
+        this.issuedAt = issuedAt;
+        return this;
+    }
+
+    public Map<String, Object> build() {
+        claims.put("iat", issuedAt.toEpochSecond(ZoneOffset.UTC));
+        claims.put("exp", expiredAt.toEpochSecond(ZoneOffset.UTC));
+        claims.put("iss", issuer);
+        return claims;
+    }
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/my_jwt/MyJwtUtil.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/my_jwt/MyJwtUtil.java
@@ -1,0 +1,121 @@
+package com.yeohaeng_ttukttak.server.common.util.my_jwt;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yeohaeng_ttukttak.server.common.util.my_jwt.exception.*;
+import lombok.NoArgsConstructor;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.yeohaeng_ttukttak.server.common.util.MyStringUtil.fromBase64Url;
+import static com.yeohaeng_ttukttak.server.common.util.MyStringUtil.toBase64Url;
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+public class MyJwtUtil {
+
+    private static final String SIGNATURE_ALGORITHM = "HmacSHA256";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String HEADER = "eyJ0eXBlIjoiSldUIiwiYWxnIjoiSFMyNTYifQ";
+
+    /**
+     * 제공된 비밀 키와 클레임을 기반으로 JWT 토큰을 생성합니다. HmacSHA256 해시 함수로 서명을 생성합니다.
+     *
+     * @param secret 토큰 서명에 사용될 비밀 키
+     * @param claims 토큰 페이로드에 포함될 클레임
+     * @return 생성된 JWT 토큰
+     */
+    public static String issue(String secret, Map<String, Object> claims) {
+        String content = HEADER + "." + serialize(claims);
+        String signature = generateSignature(secret, content);
+        return content + "." + signature;
+    }
+
+    private static String generateSignature(String secret, String content) {
+        try {
+            Mac mac = Mac.getInstance(SIGNATURE_ALGORITHM);
+            SecretKeySpec secretKeySpec = new SecretKeySpec(secret.getBytes(), SIGNATURE_ALGORITHM);
+            mac.init(secretKeySpec);
+            byte[] signatureBytes = mac.doFinal(content.getBytes());
+            return toBase64Url(signatureBytes);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new TokenSignatureException();
+        }
+    }
+
+    /**
+     * HmacSHA256으로 서명된 JWT 토큰을 검증 후 해독 합니다.
+     *
+     * @param secret 토큰 서명 검증에 사용될 비밀 키
+     * @param token  검증하고 디코딩할 JWT 토큰
+     * @return 토큰의 페이로드를 나타내는 맵(Map)
+     * @throws TokenSignatureNotMatchedException 토큰의 서명이 예상된 서명과 일치하지 않는 경우
+     * @throws InvalidTokenException             토큰 형식이 올바르지 않은 경우
+     * @throws ExpiredTokenException             토큰이 만료된 경우
+     */
+    public static Map<String, Object> validateAndDecode(String secret, String token) {
+
+        String[] parts = splitToken(token);
+
+        String content = parts[0] + "." + parts[1];
+        String signature = parts[2];
+
+        if (!generateSignature(secret, content).equals(signature)) {
+            throw new TokenSignatureNotMatchedException();
+        }
+
+        Map<String, Object> payload = decode(parts[1]);
+
+        validateExpiration(payload);
+
+        return payload;
+    }
+
+    public static Map<String, Object> decode(String token) {
+        try {
+
+            String[] parts = splitToken(token);
+
+            return objectMapper.readValue(fromBase64Url(parts[1]), new TypeReference<>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String serialize(Object object) {
+        try {
+            String json = objectMapper.writeValueAsString(object);
+            return toBase64Url(json.getBytes());
+        } catch (JsonProcessingException e) {
+            throw new TokenSerializationException();
+        }
+    }
+
+    private static void validateExpiration(Map<String, Object> payload) {
+        Instant expiration = Optional.ofNullable(payload.get("exp"))
+                .map(value -> Instant.ofEpochSecond(Long.parseLong(value.toString())))
+                .orElseThrow(InvalidTokenException::new);
+
+        if (expiration.isBefore(Instant.now())) {
+            throw new ExpiredTokenException();
+        }
+    }
+
+    private static String[] splitToken(String token) {
+        String[] parts = token.split("\\.");
+
+        if (parts.length != 3) {
+            throw new InvalidTokenException();
+        }
+
+        return parts;
+    }
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/my_jwt/exception/ExpiredTokenException.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/my_jwt/exception/ExpiredTokenException.java
@@ -1,0 +1,3 @@
+package com.yeohaeng_ttukttak.server.common.util.my_jwt.exception;
+
+public class ExpiredTokenException extends RuntimeException { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/my_jwt/exception/InvalidTokenException.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/my_jwt/exception/InvalidTokenException.java
@@ -1,0 +1,3 @@
+package com.yeohaeng_ttukttak.server.common.util.my_jwt.exception;
+
+public class InvalidTokenException extends RuntimeException { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/my_jwt/exception/TokenSerializationException.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/my_jwt/exception/TokenSerializationException.java
@@ -1,0 +1,3 @@
+package com.yeohaeng_ttukttak.server.common.util.my_jwt.exception;
+
+public class TokenSerializationException extends RuntimeException { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/my_jwt/exception/TokenSignatureException.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/my_jwt/exception/TokenSignatureException.java
@@ -1,0 +1,3 @@
+package com.yeohaeng_ttukttak.server.common.util.my_jwt.exception;
+
+public class TokenSignatureException extends RuntimeException { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/my_jwt/exception/TokenSignatureNotMatchedException.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/util/my_jwt/exception/TokenSignatureNotMatchedException.java
@@ -1,0 +1,3 @@
+package com.yeohaeng_ttukttak.server.common.util.my_jwt.exception;
+
+public class TokenSignatureNotMatchedException extends RuntimeException { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/controller/dto/UserController.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/controller/dto/UserController.java
@@ -1,5 +1,7 @@
 package com.yeohaeng_ttukttak.server.user.controller.dto;
 
+import com.yeohaeng_ttukttak.server.common.util.my_jwt.MyJwtUtil;
+import com.yeohaeng_ttukttak.server.user.domain.User;
 import com.yeohaeng_ttukttak.server.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +21,13 @@ public class UserController {
     @GetMapping("/sign-up")
     public void signUp(@RequestParam String code) {
         log.info("code={}", code);
-        userService.signUp(code);
+        User user = userService.signUp(code);
+
+    }
+
+    @GetMapping("/revoke")
+    public void revoke(@RequestParam String code) {
+
     }
 
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/domain/Gender.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/domain/Gender.java
@@ -1,0 +1,5 @@
+package com.yeohaeng_ttukttak.server.user.domain;
+
+public enum Gender {
+    MALE, FEMALE, NONE
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/domain/User.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/domain/User.java
@@ -1,0 +1,43 @@
+package com.yeohaeng_ttukttak.server.user.domain;
+
+import com.yeohaeng_ttukttak.server.common.entity.TimeAuditableEntity;
+import com.yeohaeng_ttukttak.server.user.domain.auth.OAuth;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Entity
+@Table(name = "users")
+@NoArgsConstructor(access = PROTECTED)
+public class User extends TimeAuditableEntity {
+
+    @Id @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String nickname;
+
+    @NotNull
+    private Gender gender;
+
+    @NotNull
+    private LocalDate birthday;
+
+    @NotNull @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "auth_id", updatable = false)
+    private OAuth auth;
+
+    public User(OAuth auth, String nickname, Gender gender, LocalDate birthday) {
+        this.nickname = nickname;
+        this.gender = gender;
+        this.birthday = birthday;
+        this.auth = auth;
+    }
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/domain/auth/OAuth.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/domain/auth/OAuth.java
@@ -1,0 +1,27 @@
+package com.yeohaeng_ttukttak.server.user.domain.auth;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class OAuth {
+
+    @Id @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @NotNull @Column(unique = true, updatable = false)
+    private String openId;
+
+    private OAuthProvider provider;
+
+    public OAuth(String openId, OAuthProvider provider) {
+        this.openId = openId;
+        this.provider = provider;
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/domain/auth/OAuthProvider.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/domain/auth/OAuthProvider.java
@@ -1,0 +1,7 @@
+package com.yeohaeng_ttukttak.server.user.domain.auth;
+
+public enum OAuthProvider {
+
+    GOOGLE, APPLE
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/repository/UserRepository.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.yeohaeng_ttukttak.server.user.repository;
+
+import com.yeohaeng_ttukttak.server.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Query("SELECT u FROM User u WHERE u.auth.openId = :openId")
+    Optional<User> findByOpenId(String openId);
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/GoogleProfileClient.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/GoogleProfileClient.java
@@ -14,8 +14,6 @@ import org.springframework.web.service.annotation.HttpExchange;
 public interface GoogleProfileClient {
 
     @GetExchange("/people/me?personFields=birthdays,genders")
-    GetProfileResponse getProfile(
-            @RequestHeader(name = "Authorization")
-            String authorization);
+    GetProfileResponse getProfile();
 
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/dto/ExchangeTokenResponse.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/user/service/client/dto/ExchangeTokenResponse.java
@@ -1,9 +1,11 @@
 package com.yeohaeng_ttukttak.server.user.service.client.dto;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record ExchangeTokenResponse (
         @JsonProperty("access_token") String accessToken,
-        @JsonProperty("refresh_token") String refreshToken
+        @JsonProperty("id_token") String idToken
 ) { }

--- a/server/src/test/java/com/yeohaeng_ttukttak/server/common/util/MyJwtUtilTest.java
+++ b/server/src/test/java/com/yeohaeng_ttukttak/server/common/util/MyJwtUtilTest.java
@@ -1,0 +1,111 @@
+package com.yeohaeng_ttukttak.server.common.util;
+
+import com.yeohaeng_ttukttak.server.common.util.my_jwt.MyJwtClaimBuilder;
+import com.yeohaeng_ttukttak.server.common.util.my_jwt.MyJwtUtil;
+import com.yeohaeng_ttukttak.server.common.util.my_jwt.exception.ExpiredTokenException;
+import com.yeohaeng_ttukttak.server.common.util.my_jwt.exception.TokenSignatureNotMatchedException;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Slf4j
+class MyJwtUtilTest {
+
+    @Nested
+    @DisplayName("검증 및 해독 테스트")
+    class ValidateAndDecode {
+
+        String secret = "heebeom";
+        String issuer = "test.yeohaeng-ttukttak.com";
+        String email = "heebeom@yeohaeng-ttukttak.com";
+
+        @Test
+        void success_test() {
+
+            // Given
+            LocalDateTime expiredAt = LocalDateTime.now().plusDays(1);
+
+            Map<String, Object> claim = MyJwtClaimBuilder.create(expiredAt)
+                    .issuer(issuer)
+                    .addClaim("email", email)
+                    .build();
+
+            // when
+            String token = MyJwtUtil.issue(secret, claim);
+            Map<String, Object> payload = MyJwtUtil.validateAndDecode(secret, token);
+
+            log.info("issued={}", token);
+            log.info("decoded={}", payload);
+
+            // then
+            assertThat(payload.get("iss")).isEqualTo(issuer);
+            assertThat(payload.get("email")).isEqualTo(email);
+
+        }
+
+        @Test
+        void expiration_test() {
+
+            // Given
+            LocalDateTime expiredAt = LocalDateTime.now().minusDays(1);
+            Map<String, Object> claim = MyJwtClaimBuilder.create(expiredAt)
+                    .issuer(issuer)
+                    .addClaim("email", email)
+                    .build();
+
+            // when
+            String token = MyJwtUtil.issue(secret, claim);
+
+            // then
+            assertThatThrownBy(() -> MyJwtUtil.validateAndDecode(secret, token))
+                    .as("토큰 유효기간이 만료된 경우 예외가 발생한다.")
+                    .isInstanceOf(ExpiredTokenException.class);
+
+        }
+
+        @Test
+        void change_test() {
+
+            // Given
+            LocalDateTime expiredAt = LocalDateTime.now().minusDays(1);
+            Map<String, Object> claim = MyJwtClaimBuilder.create(expiredAt)
+                    .issuer(issuer)
+                    .addClaim("email", email)
+                    .build();
+
+            // when
+            String token = MyJwtUtil.issue(secret, claim);
+
+            String[] parts = token.split("\\.");
+
+            /*
+               토큰의 유효 기간을 변조한 값으로 대체
+                {
+                    "iss": "test.yeohaeng-ttukttak.com",
+                    "exp": 1824332140, <-- 2027년 8월 24일로 변조
+                    "iat": 1724245740,
+                    "email": "heebeom@yeohaeng-ttukttak.com"
+                }
+            */
+            String changedPayload = "eyJpc3MiOiJ0ZXN0Lnllb2hhZW5nLXR0dWt0dGFrLmNvbSIsImV4cCI6MTcyNDQzMjE0MCwiaWF0IjoxNzI0MjQ1NzQwLCJlbWFpbCI6ImhlZWJlb21AeWVvaGFlbmctdHR1a3R0YWsuY29tIn0";
+            String changeToken = parts[0] + "." + changedPayload + "." + parts[2];
+
+            // then
+            assertThatThrownBy(() -> MyJwtUtil.validateAndDecode(secret, changeToken))
+                    .as("토큰이 변조된 경우, 서명 불일치 예외가 발생한다.")
+                    .isInstanceOf(TokenSignatureNotMatchedException.class);
+
+        }
+
+
+    }
+
+
+}

--- a/server/src/test/java/com/yeohaeng_ttukttak/server/user/domain/UserTest.java
+++ b/server/src/test/java/com/yeohaeng_ttukttak/server/user/domain/UserTest.java
@@ -1,0 +1,83 @@
+package com.yeohaeng_ttukttak.server.user.domain;
+
+import com.yeohaeng_ttukttak.server.user.domain.auth.OAuth;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.time.LocalDate;
+import java.util.Date;
+
+import static com.yeohaeng_ttukttak.server.user.domain.auth.OAuthProvider.GOOGLE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+class UserTest {
+
+    @Autowired
+    TestEntityManager em;
+
+    record Profile (String name, Gender gender, LocalDate brithDate) {}
+
+    Profile profile;
+    OAuth auth;
+
+    @BeforeEach
+    void setup() {
+        profile = new Profile("Heebeom", Gender.MALE, LocalDate.of(1998, 11, 17));
+
+        auth = new OAuth("710372FA94275862C0B2", GOOGLE);
+
+        em.persist(auth);
+    }
+
+    @Test
+    void create_success_test() {
+        // given
+        User user = new User(auth, profile.name(), profile.gender(), profile.brithDate());
+
+        // when
+        em.persist(user);
+
+        // then
+        assertThat(user.getId()).isNotNull();
+        assertThat(user.getAuth()).isEqualTo(auth);
+    }
+
+    @Test
+    void nickname_null_test() {
+        // given
+        User user = new User(auth, null, profile.gender(), profile.brithDate());
+
+        // when, then
+        assertThatThrownBy(() -> em.persist(user))
+                .as("닉네임(nickname)이 null 값이면 빈 검증기 레벨에서 예외가 발생한다.")
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void gender_null_test() {
+        // given
+        User user = new User(auth, profile.name(), null, profile.brithDate());
+
+        // when, then
+        assertThatThrownBy(() -> em.persist(user))
+                .as("성별(gender)이 null 값이면 빈 검증기 레벨에서 예외가 발생한다.")
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void brith_date_null_test() {
+        // given
+        User user = new User(auth, profile.name(), profile.gender(), null);
+
+        // when, then
+        assertThatThrownBy(() -> em.persist(user))
+                .as("생년월일(brithday)이 null 값이면 빈 검증기 레벨에서 예외가 발생한다.")
+                .isInstanceOf(ConstraintViolationException.class);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> Ex. close #이슈 번호, #이슈 번호

#4 

## 📝 작업 내용
> 작업한 내용을 간략히 설명해 주세요.

- [x] JWT 유틸 클래스 추가
  - [x] HmacSHA256 기반 토큰 발급 & 검증 구현
  - [x] 관련 테스트 코드 작성

### Google API 인증 인터셉터 구현

Google Profile API를 사용하기 위해서 액세스 토큰을 `Authorization` 헤더에 첨부해야 합니다. 원래는 `exchangeToken()` 메서드에 파라미터로 넘겨줬는데, 인증 같은 횡단 관심사가 핵심 비지니스 로직에 들어가 있어 분리헀습니다.

<br/>

그래서 AccssToken을 저장 및 사용하는 인터셉터를 만들기로 헀습니다.
- 토큰 교환 요청을 추적하고, 결과를 파싱해 `OAuth` 요청 스코프 안에 저장합니다.
- 만약 한 `OAuth` 요청 안에 저장된 토큰이 있으면 자동으로 헤더에 추가합니다. 


## ✅ 작업 결과
> 작업 내용 Notion 링크, 혹은 이미지를 첨부해 주세요.


## 💬 추가 사항 (선택)
> 추가로 기재할 사항이 있으면 기재해 주세요.

### JWT 관련 라이브러리 도입 필요성

학습한 내용을 기반으로 직접 JWT를 발급 & 검증하는 코드를 작성했지만, 제대로 된 라이브러리를 도입하고자 합니다.
- 단순히 우리 서버에서 사용할 토큰을 다루는게 아니라, 다른 API의 토큰도 다루고 있습니다. 알고리즘마다 토큰 검증 방식이 바뀌어서 관리가 힘듭니다.
