### PR TITLE
Feature(#8): 여행, 장소, 지역 객체 및 여행 생성 코드 작성

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -26,12 +26,15 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	/* Database dependency */
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
 	implementation 'com.auth0:java-jwt:4.4.0'
 
-	// AWS Parameter Store 연동을 위한 종속성
+	/* AWS cloud dependency */
 	implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.0")
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store'
 

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel/service/CreateTravelService.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel/service/CreateTravelService.java
@@ -1,0 +1,40 @@
+package com.yeohaeng_ttukttak.server.application.travel.service;
+
+import com.yeohaeng_ttukttak.server.application.travel.service.dto.CreateTravelCommand;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Member;
+import com.yeohaeng_ttukttak.server.domain.member.service.MemberService;
+import com.yeohaeng_ttukttak.server.domain.place.entity.City;
+import com.yeohaeng_ttukttak.server.domain.travel.dto.TravelDto;
+import com.yeohaeng_ttukttak.server.domain.travel.entity.InputTravel;
+import com.yeohaeng_ttukttak.server.domain.travel.entity.TravelCity;
+import com.yeohaeng_ttukttak.server.domain.travel.repository.TravelRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CreateTravelService {
+
+    private final MemberService memberService;
+    private final TravelRepository travelRepository;
+
+    @Transactional
+    public TravelDto call(CreateTravelCommand comm) {
+        final Member member = memberService.find(comm.memberId());
+
+        final InputTravel travel = new InputTravel(
+                member,
+                comm.name(),
+                comm.startedOn(),
+                comm.endedOn(),
+                comm.companionType());
+
+        comm.cities().forEach((City city) -> new TravelCity(travel, city));
+
+        travelRepository.save(travel);
+
+        return new TravelDto(travel);
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel/service/dto/CreateTravelCommand.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel/service/dto/CreateTravelCommand.java
@@ -1,0 +1,18 @@
+package com.yeohaeng_ttukttak.server.application.travel.service.dto;
+
+import com.yeohaeng_ttukttak.server.domain.place.entity.City;
+import com.yeohaeng_ttukttak.server.domain.travel.entity.CompanionType;
+import com.yeohaeng_ttukttak.server.domain.travel.entity.MotivationType;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CreateTravelCommand(
+        String memberId,
+        String name,
+        LocalDate startedOn,
+        LocalDate endedOn,
+        CompanionType companionType,
+        List<MotivationType> motivationTypes,
+        List<City> cities
+) { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/auth/dto/AccessTokenDto.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/auth/dto/AccessTokenDto.java
@@ -1,3 +1,3 @@
 package com.yeohaeng_ttukttak.server.domain.auth.dto;
 
-public record AccessTokenDto(String userId) { }
+public record AccessTokenDto(String memberId) { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/AgeGroup.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/AgeGroup.java
@@ -1,0 +1,10 @@
+package com.yeohaeng_ttukttak.server.domain.member.entity;
+
+public enum AgeGroup {
+    Twenties,
+    Thirties,
+    Forties,
+    Fifties,
+    Sixties,
+    Other
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/Member.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/Member.java
@@ -19,6 +19,10 @@ public class Member {
     @Id @GeneratedValue
     private UUID id;
 
+    @Enumerated(EnumType.STRING)
+    private AgeGroup ageGroup;
+
+    @Enumerated(EnumType.STRING)
     private Gender gender;
 
     private LocalDate birthDate;
@@ -37,4 +41,9 @@ public class Member {
     public String id() {
         return id.toString();
     }
+
+    public AgeGroup ageGroup() {
+        return ageGroup;
+    }
+
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/service/MemberService.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/service/MemberService.java
@@ -1,0 +1,24 @@
+package com.yeohaeng_ttukttak.server.domain.member.service;
+
+import com.yeohaeng_ttukttak.server.common.exception.exception.fail.InvalidAuthorizationException;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Member;
+import com.yeohaeng_ttukttak.server.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository repository;
+
+    public Member find(String memberId) {
+        return repository
+                .findById(UUID.fromString(memberId))
+                .orElseThrow(InvalidAuthorizationException::new);
+    }
+
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/place/entity/City.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/place/entity/City.java
@@ -1,0 +1,6 @@
+package com.yeohaeng_ttukttak.server.domain.place.entity;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public final class City extends Region { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/place/entity/Place.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/place/entity/Place.java
@@ -1,0 +1,32 @@
+package com.yeohaeng_ttukttak.server.domain.place.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@ToString
+@NoArgsConstructor(access = PROTECTED)
+public final class Place {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    private Integer regionCode;
+
+    private String lotNumberAddress;
+
+    private String roadAddress;
+
+    private Double longitude;
+
+    private Double latitude;
+
+
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/place/entity/PlaceCategory.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/place/entity/PlaceCategory.java
@@ -1,0 +1,20 @@
+package com.yeohaeng_ttukttak.server.domain.place.entity;
+
+import jakarta.persistence.*;
+import lombok.ToString;
+
+@Entity
+@ToString
+public class PlaceCategory {
+
+    @Id
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id")
+    private Place place;
+
+    @Enumerated(EnumType.STRING)
+    private PlaceType type;
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/place/entity/PlaceType.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/place/entity/PlaceType.java
@@ -1,0 +1,16 @@
+package com.yeohaeng_ttukttak.server.domain.place.entity;
+
+public enum PlaceType {
+    Nature,
+    Heritage,
+    Culture,
+    Commerce,
+    Recreation,
+    ThemePark,
+    Trail,
+    Festival,
+    Transport,
+    Shop,
+    Dining,
+    Other
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/place/entity/Region.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/place/entity/Region.java
@@ -1,0 +1,38 @@
+package com.yeohaeng_ttukttak.server.domain.place.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.InheritanceType.SINGLE_TABLE;
+import static lombok.AccessLevel.PROTECTED;
+
+@ToString
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@DiscriminatorColumn
+@Inheritance(strategy = SINGLE_TABLE)
+public abstract class Region {
+
+    @Id
+    private Long id;
+
+    @NotNull
+    private int code;
+
+    @NotNull
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    private Region parent;
+
+    @OneToMany(mappedBy = "parent")
+    private List<Region> children = new ArrayList<>();
+
+}
+

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/place/entity/State.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/place/entity/State.java
@@ -1,0 +1,6 @@
+package com.yeohaeng_ttukttak.server.domain.place.entity;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public final class State extends Region { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/dto/TravelDto.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/dto/TravelDto.java
@@ -1,0 +1,11 @@
+package com.yeohaeng_ttukttak.server.domain.travel.dto;
+
+import com.yeohaeng_ttukttak.server.domain.travel.entity.Travel;
+
+public record TravelDto() {
+
+    public TravelDto(Travel travel) {
+        this();
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/CompanionType.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/CompanionType.java
@@ -1,0 +1,10 @@
+package com.yeohaeng_ttukttak.server.domain.travel.entity;
+
+public enum CompanionType {
+    Alone,
+    Parent,
+    Children,
+    Cousin,
+    Friend,
+    Other
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/InitialTravel.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/InitialTravel.java
@@ -1,0 +1,21 @@
+package com.yeohaeng_ttukttak.server.domain.travel.entity;
+
+import com.yeohaeng_ttukttak.server.domain.member.entity.AgeGroup;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+
+@Entity
+@DiscriminatorValue("Initial")
+public final class InitialTravel extends Travel {
+
+    @Enumerated(EnumType.STRING)
+    private AgeGroup ageGroup;
+
+    @Override
+    public AgeGroup ageGroup() {
+        return ageGroup;
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/InputTravel.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/InputTravel.java
@@ -1,0 +1,24 @@
+package com.yeohaeng_ttukttak.server.domain.travel.entity;
+
+import com.yeohaeng_ttukttak.server.domain.member.entity.AgeGroup;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Member;
+import jakarta.persistence.*;
+
+@Entity
+@DiscriminatorValue("Input")
+public final class InputTravel extends Travel {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
+
+    @Override
+    AgeGroup ageGroup() {
+        return member.ageGroup();
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/InputTravel.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/InputTravel.java
@@ -3,17 +3,32 @@ package com.yeohaeng_ttukttak.server.domain.travel.entity;
 import com.yeohaeng_ttukttak.server.domain.member.entity.AgeGroup;
 import com.yeohaeng_ttukttak.server.domain.member.entity.Member;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDate;
 
 @Entity
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DiscriminatorValue("Input")
 public final class InputTravel extends Travel {
+
+    private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public void setMember(Member member) {
+    public InputTravel(Member member, String name, LocalDate startedOn, LocalDate endedOn, CompanionType companionType) {
+        super(startedOn, endedOn, companionType);
         this.member = member;
+        this.name = name;
+    }
+
+    public String name() {
+        return name;
     }
 
     @Override

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/MotivationType.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/MotivationType.java
@@ -1,0 +1,13 @@
+package com.yeohaeng_ttukttak.server.domain.travel.entity;
+
+public enum MotivationType {
+    Adventure,
+    Rest,
+    Friendship,
+    SelfDiscovery,
+    SNS,
+    Fitness,
+    NewExperiences,
+    Education,
+    Special
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/Travel.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/Travel.java
@@ -1,22 +1,26 @@
 package com.yeohaeng_ttukttak.server.domain.travel.entity;
 
 import com.yeohaeng_ttukttak.server.domain.member.entity.AgeGroup;
+import com.yeohaeng_ttukttak.server.domain.place.entity.City;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.InheritanceType.SINGLE_TABLE;
 
 @Entity
 @ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Inheritance(strategy = SINGLE_TABLE)
 public abstract class Travel {
 
     @Id
     private Long id;
-
-    private String name;
 
     private LocalDate startedOn;
 
@@ -25,6 +29,22 @@ public abstract class Travel {
     @Enumerated(EnumType.STRING)
     private CompanionType companionType;
 
+    @OneToMany(mappedBy = "travel", cascade = CascadeType.PERSIST)
+    public List<TravelCity> cities = new ArrayList<>();
+
+    @OneToMany(mappedBy = "travel", cascade = CascadeType.PERSIST)
+    public List<TravelMotivation> motivations = new ArrayList<>();
+
+    public Travel(LocalDate startedOn, LocalDate endedOn, CompanionType companionType) {
+        this.startedOn = startedOn;
+        this.endedOn = endedOn;
+        this.companionType = companionType;
+    }
+
     abstract AgeGroup ageGroup();
+
+    public List<TravelCity> cities() {
+        return cities;
+    }
 
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/Travel.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/Travel.java
@@ -1,0 +1,30 @@
+package com.yeohaeng_ttukttak.server.domain.travel.entity;
+
+import com.yeohaeng_ttukttak.server.domain.member.entity.AgeGroup;
+import jakarta.persistence.*;
+import lombok.ToString;
+
+import java.time.LocalDate;
+
+import static jakarta.persistence.InheritanceType.SINGLE_TABLE;
+
+@Entity
+@ToString
+@Inheritance(strategy = SINGLE_TABLE)
+public abstract class Travel {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    private LocalDate startedOn;
+
+    private LocalDate endedOn;
+
+    @Enumerated(EnumType.STRING)
+    private CompanionType companionType;
+
+    abstract AgeGroup ageGroup();
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/TravelCity.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/TravelCity.java
@@ -1,0 +1,22 @@
+package com.yeohaeng_ttukttak.server.domain.travel.entity;
+
+import com.yeohaeng_ttukttak.server.domain.place.entity.City;
+import jakarta.persistence.*;
+import lombok.ToString;
+
+@Entity
+@ToString
+public class TravelCity {
+
+    @Id
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "travel_id")
+    private Travel travel;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "city_id")
+    private City city;
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/TravelCity.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/TravelCity.java
@@ -2,9 +2,12 @@ package com.yeohaeng_ttukttak.server.domain.travel.entity;
 
 import com.yeohaeng_ttukttak.server.domain.place.entity.City;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString
 public class TravelCity {
 
@@ -18,5 +21,11 @@ public class TravelCity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "city_id")
     private City city;
+
+    public TravelCity(Travel travel, City city) {
+        this.travel = travel;
+        this.city = city;
+        travel.cities().add(this);
+    }
 
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/TravelMotivation.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/TravelMotivation.java
@@ -1,9 +1,12 @@
 package com.yeohaeng_ttukttak.server.domain.travel.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @ToString
 public class TravelMotivation {
 
@@ -17,4 +20,10 @@ public class TravelMotivation {
     @Enumerated(EnumType.STRING)
     private MotivationType motivationType;
 
+    public TravelMotivation(Travel travel, MotivationType motivationType) {
+        this.travel = travel;
+        this.motivationType = motivationType;
+
+        travel.motivations.add(this);
+    }
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/TravelMotivation.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/TravelMotivation.java
@@ -1,0 +1,20 @@
+package com.yeohaeng_ttukttak.server.domain.travel.entity;
+
+import jakarta.persistence.*;
+import lombok.ToString;
+
+@Entity
+@ToString
+public class TravelMotivation {
+
+    @Id
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tarvel_id")
+    private Travel travel;
+
+    @Enumerated(EnumType.STRING)
+    private MotivationType motivationType;
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/TravelVisit.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/entity/TravelVisit.java
@@ -1,0 +1,24 @@
+package com.yeohaeng_ttukttak.server.domain.travel.entity;
+
+import com.yeohaeng_ttukttak.server.domain.place.entity.Place;
+import jakarta.persistence.*;
+import lombok.ToString;
+
+@Entity
+@ToString
+public class TravelVisit {
+
+    @Id
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id")
+    private Place place;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "travel_id")
+    private Travel travel;
+
+    private int order;
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/repository/TravelRepository.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/repository/TravelRepository.java
@@ -1,0 +1,7 @@
+package com.yeohaeng_ttukttak.server.domain.travel.repository;
+
+import com.yeohaeng_ttukttak.server.domain.travel.entity.Travel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TravelRepository extends JpaRepository<Travel, Long> {
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -5,10 +5,10 @@ spring:
     import: aws-parameterstore:/yeohaeng-ttukttak/server_dev/
 
   datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:tcp://localhost/~/yeohaeng-ttukttak
-    username: sa
-    password:
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://localhost:3306/yeohaeng_ttukttak?characterEncoding=UTF-8&serverTimezone=UTC
+    username: root
+    password: 3520
 
   jpa:
     hibernate:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> Ex. close #이슈 번호, #이슈 번호

#8 
<br/>

## 📝 작업 내용
> 작업한 내용을 간략히 설명해 주세요.

### 장소, 지역 객체 작성
데이터셋의 지역 코드는  `00(도/광역시) + 000(시/군/구) +  000(동) + 0(리)` 형식입니다. 여기서 `시/군/구` 범주까지 활용해 데이터셋을 구성했습니다.
- 광역시 혹은 큰 시도의 경우 구 단위로 데이터를 보는게 맞다고 생각했습니다. 특히 서울시의 경우 이동에만 몇 시간이 걸릴 수도 있습니다.

그리고 코드 뒤에 Padding (0)을 붙여 모두 9자리 정수로 표현했습니다. 이는 추후 POI 데이터 시/군/구 검색 시 효율적이고 유연하게 대응하기 위함입니다.
- 서울 특별시의 모든 장소를 검색하려면 `110000000`에서 `1200000000` 사이를 조회하면 됩되고, 서울시 중구 안의 장소를 검색하려면 `114000000`와 `115000000` 사이를 검색하면 됩니다.
- 정수 범위 검색은 B+ Tree 인덱스에 최적화된 구조이기 때문에 이를 선택했습니다. (추후 대규모 데이터 입력 후에 개선해보면 좋을 것 같습니다)

<br/>

### 여행 객체 작성
여행 데이터는 사용자가 입력할 수도 있지만, 대부분은 외부 데이터셋에서 불러오는 형식입니다. 여행자 연령대를 제공해야 하는데, 정합성을 맞추기 위해서 `Travel`객체를 `InitialTravel`과 `InputTravel`로 분리했습니다.
- 'Travel'은 추상 클래스로 연령대 `Getter`를 추상 메서드로 선언했습니다.
- `InitialTravel`은 단순히 `AgeGroup`을 속성으로 가지고 있고, Getter로 값을 제공합니다.
- `InputTravel`은 `Member`와 연관 관계를 가지고 있고, 객체 그래프 탐색으로 값을 제공합니다.
 
<br/>

## ✅ 작업 결과
> 작업 내용 Notion 링크, 혹은 이미지를 첨부해 주세요.

```mermaid
classDiagram
    class Travel {
        +Long id
        +LocalDate startedOn
        +LocalDate endedOn
        +CompanionType companionType
    }

    class InputTravel {
        +String name
    }

    class InitialTravel {
        +AgeGroup ageGroup
    }

    class TravelMotivation {
        +Long id
        +MotivationType motivationType
    }

    class TravelCity {
        +Long id
    }

    class TravelVisit {
        +Long id
        +int order
    }

    class Place {
        +Long id
        +String name
        +Integer regionCode
        +String lotNumberAddress
        +String roadAddress
        +Double longitude
        +Double latitude
    }

    class PlaceCategory {
        +Long id
        +PlaceType type
    }

    class Region {
        +Long id
        +int code
        +String name
    }

    class State {
        <<extends Region>>
    }

    Travel <|-- InputTravel : extends
    Travel <|-- InitialTravel : extends

    Travel "1" --> "0..*" TravelMotivation : has
    Travel "1" --> "0..*" TravelCity : has
    Travel "1" --> "0..*" TravelVisit : has
    TravelMotivation "0..*" --> "1" Travel : belongs to
    TravelCity "0..*" --> "1" Travel : belongs to
    TravelVisit "0..*" --> "1" Travel : belongs to
    TravelVisit "0..*" --> "1" Place : visits
    Place "1" --> "0..*" PlaceCategory : has
    PlaceCategory "0..*" --> "1" Place : belongs to
    Region "1" --> "0..*" Region : has children
    Region "0..*" --> "1" Region : has parent
    State "0..*" --> "1" Region : extends

```

<br/>

## 💬 추가 사항 (선택)
> 추가로 기재할 사항이 있으면 기재해 주세요.

### 도메인 서비스 도입

`Member` 객체를 찾는 와중에 도메인 서비스 도입 필요성을 느꼈습니다.
- `Member` 객체를 찾지 못할 경우, 단순히 객체가 없는게 아니라 인증 정보가 잘못됬다는 예외를 발생해야 합니다.
- 도메인 주도 개발 방법론에서, 이처럼 객체 안에 풀어낼 수 없는 비즈니스 로직이 필요할 때 **최소한**으로 사용하는게 옳아 보입니다.

> [[DDD] 도메인 서비스, Domain Service](https://lucathree.com/ddd-domainservice)

### 여러 개 `Enum` 객체를 지정하는 방법
`@ElementCollection` 대신 다대다 연관 객체를 만들어 지정했습니다.

> [enum을 list로 어떻게 받는지 궁금합니다.](https://www.inflearn.com/community/questions/21303/enum%EC%9D%84-list%EB%A1%9C-%EC%96%B4%EB%96%BB%EA%B2%8C-%EB%B0%9B%EB%8A%94%EC%A7%80-%EA%B6%81%EA%B8%88%ED%95%A9%EB%8B%88%EB%8B%A4?srsltid=AfmBOopB-R9gY79It-dzqSsz_wTX9ryZinAA7OXwMeGWcwZZBLO-y6iI)

### 연관 관계 메서드의 위치
다대다 연관 관계 객체일 경우 다대다 객체 안에 연관 관계 메서드를 위치시키는게 좋을 것 같습니다.

> [JPA 연관관계 편의 메서드의 위치에 대한 내 생각](https://studyandwrite.tistory.com/535)
