### PR TITLE
Feature(#12): 관광 명소 카테고리 필터, 지도 뷰 구현

### DIFF
--- a/application/assets/translations/en.yaml
+++ b/application/assets/translations/en.yaml
@@ -137,3 +137,7 @@ enum:
   PlaceSortType:
     rating: Top Rated
     popularity: Most Popular
+
+  PlaceViewType:
+    map: Map
+    list: List

--- a/application/assets/translations/en.yaml
+++ b/application/assets/translations/en.yaml
@@ -40,6 +40,7 @@ travel_plan_recommend:
 
 city_place_pois:
   sort_by: Sort By
+  all: All
 
 next: Next
 korea: Republic of Korea

--- a/application/assets/translations/ko.yaml
+++ b/application/assets/translations/ko.yaml
@@ -42,6 +42,7 @@ travel_plan_recommend:
 
 city_place_pois:
   sort_by: 정렬 조건을 선택하세요.
+  all: 전체
 
 next: 다음으로
 korea: 대한민국

--- a/application/assets/translations/ko.yaml
+++ b/application/assets/translations/ko.yaml
@@ -143,3 +143,7 @@ enum:
   PlaceSortType:
     rating: 평점 높은 순
     popularity: 많이 방문한 순
+
+  PlaceViewType:
+    map: 지도
+    list: 목록

--- a/application/lib/feature/travel_plan/city_place_pois/component/city_place_list_item.dart
+++ b/application/lib/feature/travel_plan/city_place_pois/component/city_place_list_item.dart
@@ -20,7 +20,8 @@ class CityPlaceListItem extends StatelessWidget {
         TextStyle(fontSize: 13.0, color: colorScheme.onSurfaceVariant);
 
     return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 12.0),
+      color: colorScheme.surface,
+      padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 12.0),
       child: Row(children: [
         Expanded(
             flex: 4,

--- a/application/lib/feature/travel_plan/city_place_pois/component/city_place_list_item.dart
+++ b/application/lib/feature/travel_plan/city_place_pois/component/city_place_list_item.dart
@@ -1,3 +1,4 @@
+import 'package:application_new/common/util/string_extension.dart';
 import 'package:application_new/common/util/translation.dart';
 import 'package:application_new/feature/travel_plan/city_place_pois/provider/city_place_pois_state.dart';
 import 'package:application_new/shared/component/small_chip.dart';
@@ -22,34 +23,36 @@ class CityPlaceListItem extends StatelessWidget {
     return Container(
       color: colorScheme.surface,
       padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 12.0),
-      child: Row(children: [
-        Expanded(
-            flex: 4,
+      child: IntrinsicHeight(
+        child: Row(children: [
+          Expanded(
+            flex: 6,
             child: ClipRRect(
                 borderRadius: BorderRadius.circular(8.0),
-                child: Container(
-                    height: 80.0, color: colorScheme.primaryContainer))),
-        const Spacer(flex: 1),
-        Expanded(
-            flex: 16,
-            child:
-                Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-              Text(place.name, style: titleStyle),
-              Text(place.address.value ?? '', style: subTitleStyle, overflow: TextOverflow.ellipsis),
-              const SizedBox(height: 4.0),
-              Wrap(spacing: 8.0, children: [
-                if (rating != null)
-                  SmallChip(
-                      backgroundColor: colorScheme.primary,
-                      foregroundColor: colorScheme.onPrimary,
-                      leading: Icon(Icons.star_rate_rounded,
-                          color: colorScheme.onPrimary),
-                      label: rating.toStringAsFixed(2)),
-                for (final categoryType in place.categoryTypes)
-                  SmallChip(label: enumKey(categoryType).tr()),
-              ])
-            ])),
-      ]),
+                child: Container(color: colorScheme.primaryContainer)),
+          ),
+          const Spacer(flex: 1),
+          Expanded(
+              flex: 16,
+              child:
+                  Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+                Text(place.name, style: titleStyle),
+                Text(place.address.value?.lineBreakByWord() ?? '', style: subTitleStyle),
+                const SizedBox(height: 8.0),
+                Wrap(spacing: 8.0, children: [
+                  if (rating != null)
+                    SmallChip(
+                        backgroundColor: colorScheme.primary,
+                        foregroundColor: colorScheme.onPrimary,
+                        leading: Icon(Icons.star_rate_rounded,
+                            color: colorScheme.onPrimary),
+                        label: rating.toStringAsFixed(2)),
+                  for (final categoryType in place.categoryTypes)
+                    SmallChip(label: enumKey(categoryType).tr()),
+                ]),
+              ])),
+        ]),
+      ),
     );
   }
 }

--- a/application/lib/feature/travel_plan/city_place_pois/component/city_places_map.dart
+++ b/application/lib/feature/travel_plan/city_place_pois/component/city_places_map.dart
@@ -15,7 +15,8 @@ class CityPlacesMap extends ConsumerStatefulWidget {
   final List<PlaceModel> places;
   final double bottomPadding;
 
-  const CityPlacesMap({super.key, required this.places, this.bottomPadding = 0.0});
+  const CityPlacesMap(
+      {super.key, required this.places, this.bottomPadding = 0.0});
 
   @override
   ConsumerState createState() => _CityPlacesMapState();
@@ -27,7 +28,7 @@ class _CityPlacesMapState extends ConsumerState<CityPlacesMap> {
   Style? mapStyle;
 
   final double markerRadius = 26.0;
-  double zoom = 15.0;
+  double zoom = 16.0;
 
   List<Marker> markers = [];
 
@@ -43,11 +44,12 @@ class _CityPlacesMapState extends ConsumerState<CityPlacesMap> {
     super.initState();
   }
 
-  Future<Style> fetchStyle() => StyleReader(
-          uri:
-              'https://kr-api.tomtom.com/style/2/custom/style/dG9tdG9tQEBAQU1MSkFRZ1QyNjU0NU9WODs0OWFjMTBhMi0yODM5LTQ4NjItYjczMi01NGEwN2JiYTI0Y2I=/drafts/0.json?key={key}',
+  Future<Style> fetchStyle() async {
+    return StyleReader(
+          uri: 'https://api.tomtom.com/style/2/custom/style/dG9tdG9tQEBAQU1MSkFRZ1QyNjU0NU9WODthMzc4MGJhYy00Y2FhLTQxZmMtYWZjOS1hN2I1ZTMxODJkZjU=/drafts/0.json?key={key}',
           apiKey: const String.fromEnvironment('TOMTOM_API_KEY'))
       .read();
+  }
 
   Future<void> moveToPlace(PlaceModel? place) async {
     if (place == null) return;
@@ -83,7 +85,10 @@ class _CityPlacesMapState extends ConsumerState<CityPlacesMap> {
       children: [
         FlutterMap(
           mapController: mapController,
-          options: MapOptions(onMapReady: () => moveToPlace(widget.places.first)),
+          options: MapOptions(
+              onMapReady: () => moveToPlace(widget.places.first),
+              maxZoom: 22.0,
+              initialZoom: mapStyle?.zoom ?? zoom),
           children: [
             if (mapStyle != null)
               VectorTileLayer(

--- a/application/lib/feature/travel_plan/city_place_pois/component/place_metric_card_indicator.dart
+++ b/application/lib/feature/travel_plan/city_place_pois/component/place_metric_card_indicator.dart
@@ -1,0 +1,33 @@
+import 'package:application_new/feature/travel_plan/city_place_pois/provider/city_place_pois_provider.dart';
+import 'package:application_new/feature/travel_plan/city_place_pois/provider/city_place_pois_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:visibility_detector/visibility_detector.dart';
+
+class PlaceMetricCardIndicator extends ConsumerWidget {
+
+  final int cityId;
+  final PlaceSortType sortType;
+
+  const PlaceMetricCardIndicator(this.cityId, this.sortType, {super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData(:textTheme, :colorScheme) = Theme.of(context);
+
+    return VisibilityDetector(
+      key: const ValueKey('card-indicator'),
+      onVisibilityChanged: (info) {
+        final isVisible = info.visibleFraction == 1.0;
+        if (!isVisible) return;
+        ref.read(cityPlacePoisProvider(cityId, sortType).notifier).fetch();
+      },
+      child: Container(
+        decoration: BoxDecoration(
+            color: colorScheme.surface,
+            borderRadius: BorderRadius.circular(8.0)),
+        child: const Center(child: CircularProgressIndicator()),
+      ),
+    );
+  }
+}

--- a/application/lib/feature/travel_plan/city_place_pois/component/place_metric_card_item.dart
+++ b/application/lib/feature/travel_plan/city_place_pois/component/place_metric_card_item.dart
@@ -1,0 +1,67 @@
+
+import 'package:application_new/common/util/string_extension.dart';
+import 'package:application_new/common/util/translation.dart';
+import 'package:application_new/feature/travel_plan/city_place_pois/provider/city_place_pois_state.dart';
+import 'package:application_new/shared/component/small_chip.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+class PlaceMetricCardItem extends StatelessWidget {
+
+  final PlaceMetricModel placeMetric;
+
+  const PlaceMetricCardItem({super.key, required this.placeMetric});
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData(:textTheme, :colorScheme) = Theme.of(context);
+
+    final PlaceMetricModel(:place, :rating) = placeMetric;
+
+    const titleStyle = TextStyle(fontSize: 19.0, fontWeight: FontWeight.w600);
+    final subTitleStyle =
+    TextStyle(fontSize: 13.0, color: colorScheme.onSurfaceVariant);
+
+    return Container(
+        decoration: BoxDecoration(
+            color: colorScheme.surface,
+            borderRadius: BorderRadius.circular(8.0)),
+        margin: const EdgeInsets.symmetric(horizontal: 8.0),
+        child: Row(children: [
+          Expanded(
+              flex: 8,
+              child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8.0),
+                  child: Container(color: colorScheme.primaryContainer))),
+          const Spacer(flex: 1),
+          Expanded(
+              flex: 12,
+              child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const SizedBox(height: 16.0),
+                    Text(place.name,
+                        style: titleStyle, overflow: TextOverflow.ellipsis),
+                    const SizedBox(height: 4.0),
+                    Text(place.address.value?.lineBreakByWord() ?? '',
+                        style: subTitleStyle,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis),
+                    const Expanded(child: SizedBox()),
+                    Wrap(spacing: 8.0, children: [
+                      if (rating != null)
+                        SmallChip(
+                            backgroundColor: colorScheme.primary,
+                            foregroundColor: colorScheme.onPrimary,
+                            leading: Icon(Icons.star_rate_rounded,
+                                color: colorScheme.onPrimary),
+                            label: rating.toStringAsFixed(2)),
+                      for (final categoryType in place.categoryTypes.take(2))
+                        SmallChip(label: enumKey(categoryType).tr()),
+                    ]),
+                    const SizedBox(height: 16.0),
+                  ])),
+          const Spacer(flex: 1),
+        ]));
+  }
+}

--- a/application/lib/feature/travel_plan/city_place_pois/component/place_metric_card_item.dart
+++ b/application/lib/feature/travel_plan/city_place_pois/component/place_metric_card_item.dart
@@ -25,6 +25,7 @@ class PlaceMetricCardItem extends StatelessWidget {
     return Container(
         decoration: BoxDecoration(
             color: colorScheme.surface,
+            border: Border.all(color: colorScheme.primaryFixedDim),
             borderRadius: BorderRadius.circular(8.0)),
         margin: const EdgeInsets.symmetric(horizontal: 8.0),
         child: Row(children: [

--- a/application/lib/feature/travel_plan/city_place_pois/page/city_place_pois_page.dart
+++ b/application/lib/feature/travel_plan/city_place_pois/page/city_place_pois_page.dart
@@ -70,10 +70,8 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
 
     final cityId = widget.cityId;
 
-    final CityPlacePoisState(
-      :placeMetrics,
-      :hasNextPage,
-    ) = ref.watch(cityPlacePoisProvider(cityId, sortType));
+    final CityPlacePoisState(:placeMetrics, :hasNextPage) =
+        ref.watch(cityPlacePoisProvider(cityId, sortType));
 
     final data = selectedTypes.isNotEmpty
         ? placeMetrics
@@ -84,9 +82,6 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
         : placeMetrics;
 
     final bottomPadding = MediaQuery.of(context).padding.bottom + 16.0;
-
-    final places =
-        placeMetrics.map((placeMetric) => placeMetric.place).toList();
 
     return Scaffold(
         backgroundColor: colorScheme.surfaceContainer,
@@ -120,31 +115,7 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
                     duration: const Duration(milliseconds: 300),
                     child: switch (viewType) {
                       PlaceViewType.list => buildListView(data),
-                      PlaceViewType.map =>
-                        Stack(alignment: Alignment.bottomCenter, children: [
-                          CityPlacesMap(places: places, bottomPadding: bottomPadding + 50.0 + cardHeight + 24.0),
-                          Container(
-                              height: cardHeight,
-                              margin: EdgeInsets.only(
-                                  bottom: bottomPadding + 50.0 + 24.0),
-                              child: PageView.builder(
-                                  controller: pageController,
-                                  onPageChanged: (pageIndex) => ref
-                                      .read(
-                                          cityPlaceMapProvider(places).notifier)
-                                      .selectPlace(places[pageIndex]),
-                                  itemCount: hasNextPage
-                                      ? data.length + 1
-                                      : data.length,
-                                  itemBuilder: (context, index) {
-                                    if (index == data.length && hasNextPage) {
-                                      return PlaceMetricCardIndicator(
-                                          cityId, sortType);
-                                    }
-                                    return PlaceMetricCardItem(
-                                        placeMetric: data[index]);
-                                  })),
-                        ])
+                      PlaceViewType.map => buildMapView(data, bottomPadding)
                     })),
             Positioned(
                 left: 0,
@@ -153,6 +124,36 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
                 child: Center(child: buildToggleViewButton()))
           ],
         ));
+  }
+
+  Stack buildMapView(List<PlaceMetricModel> data, double bottomPadding) {
+    final CityPlacePoisState(:placeMetrics, :hasNextPage) =
+        ref.watch(cityPlacePoisProvider(widget.cityId, sortType));
+
+    final bottomPadding = MediaQuery.of(context).padding.bottom + 16.0;
+
+    final places = data.map((placeMetric) => placeMetric.place).toList();
+
+    return Stack(alignment: Alignment.bottomCenter, children: [
+      CityPlacesMap(
+          places: places,
+          bottomPadding: bottomPadding + 50.0 + cardHeight + 24.0),
+      Container(
+          height: cardHeight,
+          margin: EdgeInsets.only(bottom: bottomPadding + 50.0 + 24.0),
+          child: PageView.builder(
+              controller: pageController,
+              onPageChanged: (pageIndex) => ref
+                  .read(cityPlaceMapProvider(places).notifier)
+                  .selectPlace(places[pageIndex]),
+              itemCount: hasNextPage ? data.length + 1 : data.length,
+              itemBuilder: (context, index) {
+                if (index == data.length && hasNextPage) {
+                  return PlaceMetricCardIndicator(widget.cityId, sortType);
+                }
+                return PlaceMetricCardItem(placeMetric: data[index]);
+              })),
+    ]);
   }
 
   CustomScrollView buildListView(List<PlaceMetricModel> data) {
@@ -213,10 +214,11 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
   }
 
   SingleChildScrollView buildSelectTypeView() {
+
     return SingleChildScrollView(
         scrollDirection: Axis.horizontal,
-        child: Wrap(spacing: 16.0, children: [
-          const SizedBox(width: 8.0),
+        child: Row(children: [
+          const SizedBox(width: 24.0),
           FilterChip(
               label: Text(trKey('all').tr()),
               selected: selectedTypes.isEmpty,
@@ -225,9 +227,12 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
                 selectedTypes.clear();
                 setState(() {});
               }),
-          for (final categoryType in PlaceCategoryType.pois())
+          const SizedBox(width: 12.0),
+          for (final categoryType in PlaceCategoryType.pois()) ...[
             buildFilterChip(categoryType),
-          const SizedBox(width: 24.0),
+            const SizedBox(width: 12.0),
+          ],
+          const SizedBox(width: 12.0),
         ]));
   }
 

--- a/application/lib/feature/travel_plan/city_place_pois/page/city_place_pois_page.dart
+++ b/application/lib/feature/travel_plan/city_place_pois/page/city_place_pois_page.dart
@@ -3,6 +3,7 @@ import 'package:application_new/feature/home/home_page.dart';
 import 'package:application_new/feature/travel_plan/city_place_pois/component/city_place_list_item.dart';
 import 'package:application_new/feature/travel_plan/city_place_pois/provider/city_place_pois_provider.dart';
 import 'package:application_new/feature/travel_plan/city_place_pois/provider/city_place_pois_state.dart';
+import 'package:application_new/shared/model/place_model.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -24,6 +25,10 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
   PlaceSortType sortType = PlaceSortType.rating;
 
   static const double scrollThreshold = 240.0;
+
+  final Set<PlaceCategoryType> selectedTypes = {};
+
+  final trKey = baseKey('city_place_pois');
 
   @override
   void initState() {
@@ -55,7 +60,16 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
       :hasNextPage,
     ) = ref.watch(cityPlacePoisProvider(cityId, sortType));
 
+    final data = selectedTypes.isNotEmpty
+        ? placeMetrics
+            .where((placeMetric) => selectedTypes
+                .intersection(placeMetric.place.categoryTypes.toSet())
+                .isNotEmpty)
+            .toList()
+        : placeMetrics;
+
     return Scaffold(
+        backgroundColor: colorScheme.surfaceContainer,
         appBar: AppBar(
           backgroundColor: colorScheme.surface,
           scrolledUnderElevation: 0.0,
@@ -70,8 +84,35 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
                     curve: Curves.linear))
             : null,
         body: CustomScrollView(controller: scrollController, slivers: [
-          const SliverToBoxAdapter(child: SizedBox(height: 16.0)),
           SliverToBoxAdapter(
+              child: Container(
+            decoration: BoxDecoration(
+                color: colorScheme.surfaceContainer,
+                border: Border(
+                    bottom:
+                        BorderSide(color: colorScheme.surfaceContainerHigh))),
+            padding: const EdgeInsets.symmetric(vertical: 12.0),
+            child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Wrap(spacing: 16.0, children: [
+                  const SizedBox(width: 8.0),
+                  FilterChip(
+                      label: Text(trKey('all').tr()),
+                      selected: selectedTypes.isEmpty,
+                      onSelected: (isSelected) {
+                        if (!isSelected) return;
+                        selectedTypes.clear();
+                        setState(() {});
+                      }),
+                  for (final categoryType in PlaceCategoryType.pois())
+                    buildFilterChip(categoryType),
+                  const SizedBox(width: 24.0),
+                ])),
+          )),
+          SliverToBoxAdapter(
+              child: Container(
+            padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
+            color: colorScheme.surface,
             child: Row(children: [
               const SizedBox(width: 16.0),
               TextButton(
@@ -79,7 +120,6 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
                       foregroundColor: colorScheme.onSurface),
                   onPressed: () async {
                     final sortType = await showSortTypeSelectSheet();
-
                     if (sortType == null) return;
                     setState(() => this.sortType = sortType);
                   },
@@ -90,12 +130,12 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
                     const Icon(Icons.arrow_drop_down),
                   ]))
             ]),
-          ),
+          )),
           SliverList(
               delegate: SliverChildBuilderDelegate(
                   (context, index) =>
-                      CityPlaceListItem(placeMetric: placeMetrics[index]),
-                  childCount: placeMetrics.length)),
+                      CityPlaceListItem(placeMetric: data[index]),
+                  childCount: data.length)),
           if (hasNextPage)
             SliverFillRemaining(
                 hasScrollBody: false,
@@ -109,12 +149,43 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
                         .fetch();
                   },
                   child: Container(
+                    color: colorScheme.surface,
                     constraints: const BoxConstraints(minHeight: 120.0),
                     child: const Center(child: CircularProgressIndicator()),
                   ),
                 )),
           const SliverToBoxAdapter(child: SizedBox(height: 48.0)),
         ]));
+  }
+
+  FilterChip buildFilterChip(PlaceCategoryType categoryType) {
+    final ThemeData(:textTheme, :colorScheme) = Theme.of(context);
+
+    final isSelected = selectedTypes.contains(categoryType);
+    return FilterChip(
+        deleteIcon: Icon(Icons.close, color: colorScheme.onPrimary),
+        labelPadding: const EdgeInsets.symmetric(horizontal: 8.0),
+        showCheckmark: false,
+        onDeleted: isSelected
+            ? () {
+                if (!isSelected) return;
+
+                selectedTypes.remove(categoryType);
+                setState(() {});
+              }
+            : null,
+        onSelected: (_) {
+          if (isSelected) {
+            selectedTypes.remove(categoryType);
+          } else {
+            selectedTypes.add(categoryType);
+          }
+          setState(() {});
+        },
+        label: Text(enumKey(categoryType).tr()),
+        avatar: Icon(categoryType.iconData,
+            color: isSelected ? colorScheme.onPrimary : null),
+        selected: isSelected);
   }
 
   Future<PlaceSortType?> showSortTypeSelectSheet() async {
@@ -127,10 +198,10 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
               child: Padding(
                 padding: const EdgeInsets.only(top: 24.0, bottom: 16.0),
                 child: Column(mainAxisSize: MainAxisSize.min, children: [
-                  const Row(children: [
-                    SizedBox(width: 24.0),
-                    Text('정렬 옵션',
-                        style: TextStyle(
+                  Row(children: [
+                    const SizedBox(width: 24.0),
+                    Text(trKey('sort_by').tr(),
+                        style: const TextStyle(
                             fontSize: 21.0, fontWeight: FontWeight.w600))
                   ]),
                   const SizedBox(height: 16.0),

--- a/application/lib/feature/travel_plan/city_place_pois/page/city_place_pois_page.dart
+++ b/application/lib/feature/travel_plan/city_place_pois/page/city_place_pois_page.dart
@@ -1,8 +1,12 @@
+import 'package:application_new/common/util/string_extension.dart';
 import 'package:application_new/common/util/translation.dart';
 import 'package:application_new/feature/home/home_page.dart';
 import 'package:application_new/feature/travel_plan/city_place_pois/component/city_place_list_item.dart';
+import 'package:application_new/feature/travel_plan/city_place_pois/component/place_metric_card_indicator.dart';
+import 'package:application_new/feature/travel_plan/city_place_pois/component/place_metric_card_item.dart';
 import 'package:application_new/feature/travel_plan/city_place_pois/provider/city_place_pois_provider.dart';
 import 'package:application_new/feature/travel_plan/city_place_pois/provider/city_place_pois_state.dart';
+import 'package:application_new/shared/component/small_chip.dart';
 import 'package:application_new/shared/model/place_model.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
@@ -20,9 +24,11 @@ class CityPlacePoisPage extends ConsumerStatefulWidget {
 
 class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
   final scrollController = ScrollController();
+  final pageController = PageController(viewportFraction: 0.9);
 
   bool hasScrollDown = false;
   PlaceSortType sortType = PlaceSortType.rating;
+  PlaceViewType viewType = PlaceViewType.list;
 
   static const double scrollThreshold = 240.0;
 
@@ -34,9 +40,11 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
   void initState() {
     scrollController.addListener(() {
       if (scrollController.offset <= scrollThreshold) {
+        if (!hasScrollDown) return;
         setState(() => hasScrollDown = false);
         return;
       }
+      if (hasScrollDown) return;
       setState(() => hasScrollDown = true);
     });
 
@@ -45,6 +53,7 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
 
   @override
   void dispose() {
+    pageController.dispose();
     scrollController.dispose();
     super.dispose();
   }
@@ -68,12 +77,28 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
             .toList()
         : placeMetrics;
 
+    final bottomPadding = MediaQuery.of(context).padding.bottom + 16.0;
+
     return Scaffold(
         backgroundColor: colorScheme.surfaceContainer,
         appBar: AppBar(
           backgroundColor: colorScheme.surface,
           scrolledUnderElevation: 0.0,
           title: const Text('목록'),
+          bottom: PreferredSize(
+              preferredSize: const Size.fromHeight(72.0),
+              child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 300),
+                  height: 73.0,
+                  decoration: BoxDecoration(
+                      color: switch (viewType) {
+                        PlaceViewType.list => colorScheme.surfaceContainer,
+                        PlaceViewType.map => colorScheme.surface,
+                      },
+                      border: Border(
+                          top: BorderSide(
+                              color: colorScheme.surfaceContainerHigh))),
+                  child: Center(child: buildSelectTypeView()))),
         ),
         floatingActionButton: hasScrollDown
             ? FloatingActionButton(
@@ -83,79 +108,159 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
                         milliseconds: (scrollController.offset / 5).toInt()),
                     curve: Curves.linear))
             : null,
-        body: CustomScrollView(controller: scrollController, slivers: [
-          SliverToBoxAdapter(
+        body: Stack(
+          children: [
+            Positioned.fill(
+                child: AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 300),
+                    child: switch (viewType) {
+                      PlaceViewType.list => buildListView(data),
+                      PlaceViewType.map => Stack(
+                          alignment: Alignment.bottomCenter,
+                          children: [
+                            Container(),
+                            Container(
+                              height: 160.0,
+                              margin: EdgeInsets.only(
+                                  bottom: bottomPadding + 50.0 + 24.0),
+                              child: PageView.builder(
+                                  controller: pageController,
+                                  itemCount: hasNextPage
+                                      ? data.length + 1
+                                      : data.length,
+                                  itemBuilder: (context, index) {
+                                    if (index == data.length && hasNextPage) {
+                                      return PlaceMetricCardIndicator(
+                                          cityId, sortType);
+                                    }
+                                    return PlaceMetricCardItem(
+                                        placeMetric: data[index]);
+                                  }),
+                            ),
+                          ],
+                        ),
+                    })),
+            Positioned(
+                left: 0,
+                right: 0,
+                bottom: bottomPadding,
+                child: Center(child: buildToggleViewButton()))
+          ],
+        ));
+  }
+
+  CustomScrollView buildListView(List<PlaceMetricModel> data) {
+    final ThemeData(:textTheme, :colorScheme) = Theme.of(context);
+
+    final cityId = widget.cityId;
+
+    final CityPlacePoisState(:hasNextPage) =
+        ref.watch(cityPlacePoisProvider(cityId, sortType));
+
+    return CustomScrollView(controller: scrollController, slivers: [
+      SliverToBoxAdapter(
+          child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
+        color: colorScheme.surface,
+        child:
+            Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+          TextButton(
+              style:
+                  TextButton.styleFrom(foregroundColor: colorScheme.onSurface),
+              onPressed: () async {
+                final sortType = await showSortTypeSelectSheet();
+                if (sortType == null) return;
+                setState(() => this.sortType = sortType);
+              },
+              child: Row(children: [
+                Text(enumKey(sortType).tr(),
+                    style: textTheme.bodyLarge
+                        ?.copyWith(fontWeight: FontWeight.w600)),
+                const Icon(Icons.arrow_drop_down),
+              ])),
+        ]),
+      )),
+      SliverList(
+          delegate: SliverChildBuilderDelegate(
+              (context, index) => CityPlaceListItem(placeMetric: data[index]),
+              childCount: data.length)),
+      if (hasNextPage)
+        SliverFillRemaining(
+            hasScrollBody: false,
+            child: VisibilityDetector(
+              key: const Key('key'),
+              onVisibilityChanged: (info) {
+                final isVisible = info.visibleFraction > 0.0;
+                if (!isVisible) return;
+                ref
+                    .read(cityPlacePoisProvider(cityId, sortType).notifier)
+                    .fetch();
+              },
               child: Container(
-            decoration: BoxDecoration(
-                color: colorScheme.surfaceContainer,
-                border: Border(
-                    bottom:
-                        BorderSide(color: colorScheme.surfaceContainerHigh))),
-            padding: const EdgeInsets.symmetric(vertical: 12.0),
-            child: SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                child: Wrap(spacing: 16.0, children: [
-                  const SizedBox(width: 8.0),
-                  FilterChip(
-                      label: Text(trKey('all').tr()),
-                      selected: selectedTypes.isEmpty,
-                      onSelected: (isSelected) {
-                        if (!isSelected) return;
-                        selectedTypes.clear();
-                        setState(() {});
-                      }),
-                  for (final categoryType in PlaceCategoryType.pois())
-                    buildFilterChip(categoryType),
-                  const SizedBox(width: 24.0),
-                ])),
-          )),
-          SliverToBoxAdapter(
-              child: Container(
-            padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
-            color: colorScheme.surface,
-            child: Row(children: [
-              const SizedBox(width: 16.0),
-              TextButton(
-                  style: TextButton.styleFrom(
-                      foregroundColor: colorScheme.onSurface),
-                  onPressed: () async {
-                    final sortType = await showSortTypeSelectSheet();
-                    if (sortType == null) return;
-                    setState(() => this.sortType = sortType);
-                  },
-                  child: Row(children: [
-                    Text(enumKey(sortType).tr(),
-                        style: textTheme.bodyLarge
-                            ?.copyWith(fontWeight: FontWeight.w600)),
-                    const Icon(Icons.arrow_drop_down),
-                  ]))
-            ]),
-          )),
-          SliverList(
-              delegate: SliverChildBuilderDelegate(
-                  (context, index) =>
-                      CityPlaceListItem(placeMetric: data[index]),
-                  childCount: data.length)),
-          if (hasNextPage)
-            SliverFillRemaining(
-                hasScrollBody: false,
-                child: VisibilityDetector(
-                  key: const Key('key'),
-                  onVisibilityChanged: (VisibilityInfo info) {
-                    final isVisible = info.visibleFraction > 0.0;
-                    if (!isVisible) return;
-                    ref
-                        .read(cityPlacePoisProvider(cityId, sortType).notifier)
-                        .fetch();
-                  },
-                  child: Container(
-                    color: colorScheme.surface,
-                    constraints: const BoxConstraints(minHeight: 120.0),
-                    child: const Center(child: CircularProgressIndicator()),
-                  ),
-                )),
-          const SliverToBoxAdapter(child: SizedBox(height: 48.0)),
+                color: colorScheme.surface,
+                constraints: const BoxConstraints(minHeight: 120.0),
+                child: const Center(child: CircularProgressIndicator()),
+              ),
+            )),
+      const SliverToBoxAdapter(child: SizedBox(height: 48.0)),
+    ]);
+  }
+
+  SingleChildScrollView buildSelectTypeView() {
+    return SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Wrap(spacing: 16.0, children: [
+          const SizedBox(width: 8.0),
+          FilterChip(
+              label: Text(trKey('all').tr()),
+              selected: selectedTypes.isEmpty,
+              onSelected: (isSelected) {
+                if (!isSelected) return;
+                selectedTypes.clear();
+                setState(() {});
+              }),
+          for (final categoryType in PlaceCategoryType.pois())
+            buildFilterChip(categoryType),
+          const SizedBox(width: 24.0),
         ]));
+  }
+
+  Widget buildToggleViewButton() {
+    final ThemeData(:textTheme, :colorScheme) = Theme.of(context);
+
+    return Container(
+        decoration: BoxDecoration(
+          color: colorScheme.surface,
+          borderRadius: BorderRadius.circular(12.0),
+        ),
+        child: ToggleButtons(
+            fillColor: colorScheme.primaryContainer,
+            borderColor: colorScheme.surfaceContainerHighest,
+            selectedBorderColor: colorScheme.primaryFixedDim,
+            borderRadius: BorderRadius.circular(12.0),
+            textStyle: const TextStyle(fontWeight: FontWeight.w600),
+            onPressed: (index) {
+              final viewType = PlaceViewType.values[index];
+              if (this.viewType == viewType) return;
+
+              hasScrollDown = false;
+              setState(() => this.viewType = viewType);
+            },
+            isSelected: PlaceViewType.values
+                .map((viewType) => viewType == this.viewType)
+                .toList(),
+            children: [
+              for (final viewType in PlaceViewType.values)
+                Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(viewType.iconData, size: 18.0),
+                          const SizedBox(width: 8.0),
+                          Text(enumKey(viewType).tr()),
+                        ])),
+            ]));
   }
 
   FilterChip buildFilterChip(PlaceCategoryType categoryType) {
@@ -169,7 +274,6 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
         onDeleted: isSelected
             ? () {
                 if (!isSelected) return;
-
                 selectedTypes.remove(categoryType);
                 setState(() {});
               }

--- a/application/lib/feature/travel_plan/city_place_pois/provider/city_place_map_provider.dart
+++ b/application/lib/feature/travel_plan/city_place_pois/provider/city_place_map_provider.dart
@@ -1,0 +1,42 @@
+import 'package:application_new/feature/travel_plan/city_place_pois/provider/city_place_map_state.dart';
+import 'package:application_new/feature/travel_read/components/place_marker_item.dart';
+import 'package:application_new/shared/model/place_model.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:latlong2/latlong.dart';
+import 'package:collection/collection.dart';
+
+part 'city_place_map_provider.g.dart';
+
+@riverpod
+class CityPlaceMap extends _$CityPlaceMap {
+
+  final double markerRadius = 26.0;
+
+  @override
+  CityPlaceMapState build(List<PlaceModel> places) {
+    return CityPlaceMapState(markers: _buildMarkers(places, places[0].id), selectedId: places[0].id);
+  }
+
+  List<Marker> _buildMarkers(List<PlaceModel> places, int selectedId) {
+    return places.mapIndexed((index, place) {
+      final PlaceCoordinates(:longitude, :latitude) = place.coordinates;
+
+      final isSelected = place.id == selectedId;
+
+      return Marker(
+          width: markerRadius,
+          height: markerRadius,
+          point: LatLng(latitude, longitude),
+          child: PlaceMarkerItem(place: place, isSelected: isSelected));
+    }).toList();
+  }
+
+  void selectPlace(PlaceModel place) {
+    if (state.selectedId == place.id) return;
+    state = state.copyWith(selectedId: place.id, markers: _buildMarkers(places, place.id));
+  }
+
+}
+

--- a/application/lib/feature/travel_plan/city_place_pois/provider/city_place_map_provider.g.dart
+++ b/application/lib/feature/travel_plan/city_place_pois/provider/city_place_map_provider.g.dart
@@ -1,0 +1,174 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'city_place_map_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$cityPlaceMapHash() => r'32f4968d625a95e1946ec8b5a0311e114599c9d2';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$CityPlaceMap
+    extends BuildlessAutoDisposeNotifier<CityPlaceMapState> {
+  late final List<PlaceModel> places;
+
+  CityPlaceMapState build(
+    List<PlaceModel> places,
+  );
+}
+
+/// See also [CityPlaceMap].
+@ProviderFor(CityPlaceMap)
+const cityPlaceMapProvider = CityPlaceMapFamily();
+
+/// See also [CityPlaceMap].
+class CityPlaceMapFamily extends Family<CityPlaceMapState> {
+  /// See also [CityPlaceMap].
+  const CityPlaceMapFamily();
+
+  /// See also [CityPlaceMap].
+  CityPlaceMapProvider call(
+    List<PlaceModel> places,
+  ) {
+    return CityPlaceMapProvider(
+      places,
+    );
+  }
+
+  @override
+  CityPlaceMapProvider getProviderOverride(
+    covariant CityPlaceMapProvider provider,
+  ) {
+    return call(
+      provider.places,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'cityPlaceMapProvider';
+}
+
+/// See also [CityPlaceMap].
+class CityPlaceMapProvider
+    extends AutoDisposeNotifierProviderImpl<CityPlaceMap, CityPlaceMapState> {
+  /// See also [CityPlaceMap].
+  CityPlaceMapProvider(
+    List<PlaceModel> places,
+  ) : this._internal(
+          () => CityPlaceMap()..places = places,
+          from: cityPlaceMapProvider,
+          name: r'cityPlaceMapProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$cityPlaceMapHash,
+          dependencies: CityPlaceMapFamily._dependencies,
+          allTransitiveDependencies:
+              CityPlaceMapFamily._allTransitiveDependencies,
+          places: places,
+        );
+
+  CityPlaceMapProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.places,
+  }) : super.internal();
+
+  final List<PlaceModel> places;
+
+  @override
+  CityPlaceMapState runNotifierBuild(
+    covariant CityPlaceMap notifier,
+  ) {
+    return notifier.build(
+      places,
+    );
+  }
+
+  @override
+  Override overrideWith(CityPlaceMap Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: CityPlaceMapProvider._internal(
+        () => create()..places = places,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        places: places,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeNotifierProviderElement<CityPlaceMap, CityPlaceMapState>
+      createElement() {
+    return _CityPlaceMapProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is CityPlaceMapProvider && other.places == places;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, places.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin CityPlaceMapRef on AutoDisposeNotifierProviderRef<CityPlaceMapState> {
+  /// The parameter `places` of this provider.
+  List<PlaceModel> get places;
+}
+
+class _CityPlaceMapProviderElement
+    extends AutoDisposeNotifierProviderElement<CityPlaceMap, CityPlaceMapState>
+    with CityPlaceMapRef {
+  _CityPlaceMapProviderElement(super.provider);
+
+  @override
+  List<PlaceModel> get places => (origin as CityPlaceMapProvider).places;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/application/lib/feature/travel_plan/city_place_pois/provider/city_place_map_state.dart
+++ b/application/lib/feature/travel_plan/city_place_pois/provider/city_place_map_state.dart
@@ -1,0 +1,15 @@
+import 'package:application_new/shared/model/place_model.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'city_place_map_state.freezed.dart';
+
+@freezed
+class CityPlaceMapState with _$CityPlaceMapState {
+
+  const factory CityPlaceMapState({
+    required List<Marker> markers,
+    required int selectedId,
+  }) = _CityPlaceMapState;
+
+}

--- a/application/lib/feature/travel_plan/city_place_pois/provider/city_place_map_state.freezed.dart
+++ b/application/lib/feature/travel_plan/city_place_pois/provider/city_place_map_state.freezed.dart
@@ -1,0 +1,172 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'city_place_map_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$CityPlaceMapState {
+  List<Marker> get markers => throw _privateConstructorUsedError;
+  int get selectedId => throw _privateConstructorUsedError;
+
+  /// Create a copy of CityPlaceMapState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $CityPlaceMapStateCopyWith<CityPlaceMapState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $CityPlaceMapStateCopyWith<$Res> {
+  factory $CityPlaceMapStateCopyWith(
+          CityPlaceMapState value, $Res Function(CityPlaceMapState) then) =
+      _$CityPlaceMapStateCopyWithImpl<$Res, CityPlaceMapState>;
+  @useResult
+  $Res call({List<Marker> markers, int selectedId});
+}
+
+/// @nodoc
+class _$CityPlaceMapStateCopyWithImpl<$Res, $Val extends CityPlaceMapState>
+    implements $CityPlaceMapStateCopyWith<$Res> {
+  _$CityPlaceMapStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of CityPlaceMapState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? markers = null,
+    Object? selectedId = null,
+  }) {
+    return _then(_value.copyWith(
+      markers: null == markers
+          ? _value.markers
+          : markers // ignore: cast_nullable_to_non_nullable
+              as List<Marker>,
+      selectedId: null == selectedId
+          ? _value.selectedId
+          : selectedId // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$CityPlaceMapStateImplCopyWith<$Res>
+    implements $CityPlaceMapStateCopyWith<$Res> {
+  factory _$$CityPlaceMapStateImplCopyWith(_$CityPlaceMapStateImpl value,
+          $Res Function(_$CityPlaceMapStateImpl) then) =
+      __$$CityPlaceMapStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<Marker> markers, int selectedId});
+}
+
+/// @nodoc
+class __$$CityPlaceMapStateImplCopyWithImpl<$Res>
+    extends _$CityPlaceMapStateCopyWithImpl<$Res, _$CityPlaceMapStateImpl>
+    implements _$$CityPlaceMapStateImplCopyWith<$Res> {
+  __$$CityPlaceMapStateImplCopyWithImpl(_$CityPlaceMapStateImpl _value,
+      $Res Function(_$CityPlaceMapStateImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of CityPlaceMapState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? markers = null,
+    Object? selectedId = null,
+  }) {
+    return _then(_$CityPlaceMapStateImpl(
+      markers: null == markers
+          ? _value._markers
+          : markers // ignore: cast_nullable_to_non_nullable
+              as List<Marker>,
+      selectedId: null == selectedId
+          ? _value.selectedId
+          : selectedId // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$CityPlaceMapStateImpl implements _CityPlaceMapState {
+  const _$CityPlaceMapStateImpl(
+      {required final List<Marker> markers, required this.selectedId})
+      : _markers = markers;
+
+  final List<Marker> _markers;
+  @override
+  List<Marker> get markers {
+    if (_markers is EqualUnmodifiableListView) return _markers;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_markers);
+  }
+
+  @override
+  final int selectedId;
+
+  @override
+  String toString() {
+    return 'CityPlaceMapState(markers: $markers, selectedId: $selectedId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$CityPlaceMapStateImpl &&
+            const DeepCollectionEquality().equals(other._markers, _markers) &&
+            (identical(other.selectedId, selectedId) ||
+                other.selectedId == selectedId));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(_markers), selectedId);
+
+  /// Create a copy of CityPlaceMapState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$CityPlaceMapStateImplCopyWith<_$CityPlaceMapStateImpl> get copyWith =>
+      __$$CityPlaceMapStateImplCopyWithImpl<_$CityPlaceMapStateImpl>(
+          this, _$identity);
+}
+
+abstract class _CityPlaceMapState implements CityPlaceMapState {
+  const factory _CityPlaceMapState(
+      {required final List<Marker> markers,
+      required final int selectedId}) = _$CityPlaceMapStateImpl;
+
+  @override
+  List<Marker> get markers;
+  @override
+  int get selectedId;
+
+  /// Create a copy of CityPlaceMapState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$CityPlaceMapStateImplCopyWith<_$CityPlaceMapStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/application/lib/feature/travel_plan/city_place_pois/provider/city_place_pois_state.dart
+++ b/application/lib/feature/travel_plan/city_place_pois/provider/city_place_pois_state.dart
@@ -1,4 +1,6 @@
 import 'package:application_new/shared/model/place_model.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'city_place_pois_state.freezed.dart';
@@ -26,4 +28,10 @@ class PlaceMetricModel with _$PlaceMetricModel {
 
 enum PlaceSortType { rating, popularity }
 
-enum PlaceViewType { list, map }
+enum PlaceViewType {
+  list(Icons.view_list), map(Icons.map);
+
+  final IconData iconData;
+
+  const PlaceViewType(this.iconData);
+}

--- a/application/lib/feature/travel_plan/travel_plan_recommend/component/recommend_place_item.dart
+++ b/application/lib/feature/travel_plan/travel_plan_recommend/component/recommend_place_item.dart
@@ -21,8 +21,7 @@ class RecommendPlaceItem extends StatelessWidget {
 
     final ThemeData(:textTheme, :colorScheme) = Theme.of(context);
 
-    final labelStyle =
-        textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600);
+    const labelStyle = TextStyle(fontSize: 20.0, fontWeight: FontWeight.w600);
 
     final nameStyle =
         textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w600);
@@ -41,7 +40,7 @@ class RecommendPlaceItem extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Container(
-                width: MediaQuery.of(context).size.width * 0.7,
+                width: MediaQuery.of(context).size.width * 0.6,
                 padding: const EdgeInsets.only(left: 24.0),
                 child: Text(
                     labelText,

--- a/application/lib/feature/travel_plan/travel_plan_recommend/component/recommend_travel_item.dart
+++ b/application/lib/feature/travel_plan/travel_plan_recommend/component/recommend_travel_item.dart
@@ -53,7 +53,6 @@ class _RecommendTravelItemState extends State<RecommendTravelItem> {
                   itemBuilder: (context, index) {
                     final travel = widget.recommendTravelModel.travels[index];
                     return Container(
-
                         width: double.maxFinite,
                         constraints: const BoxConstraints(maxWidth: 480.0),
                         padding: const EdgeInsets.symmetric(horizontal: 24.0),

--- a/application/lib/feature/travel_plan/travel_plan_recommend/page/travel_plan_recommend_page.dart
+++ b/application/lib/feature/travel_plan/travel_plan_recommend/page/travel_plan_recommend_page.dart
@@ -125,10 +125,19 @@ class _TravelPlanRecommendPageState
         ]),
       )),
       SliverToBoxAdapter(
-        child: Container(
-          width: double.maxFinite,
-          height: 16.0,
-          color: colorScheme.surfaceContainerLow,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: double.maxFinite,
+              height: 16.0,
+              color: colorScheme.surfaceContainerLow),
+            const SizedBox(height: 32.0),
+            Padding(
+              padding: const EdgeInsets.only(left: 24.0),
+              child: Text('추천 관광지 모음', style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600)),
+            ),
+          ],
         ),
       ),
       SliverList(

--- a/application/lib/feature/travel_read/components/visits_map_item.dart
+++ b/application/lib/feature/travel_read/components/visits_map_item.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:vector_map_tiles/vector_map_tiles.dart';
 
 class VisitsMapItem extends ConsumerStatefulWidget {
   final int travelId;
@@ -23,6 +24,14 @@ class _VisitsMapItemState extends ConsumerState<VisitsMapItem> {
   double zoom = 15.0;
 
   bool isPositionChanged = false;
+
+  Style? mapStyle;
+
+  @override
+  void initState() {
+    fetchStyle().then((style) => setState(() => mapStyle = style));
+    super.initState();
+  }
 
   @override
   void dispose() {
@@ -43,6 +52,10 @@ class _VisitsMapItemState extends ConsumerState<VisitsMapItem> {
 
     notifier.setIsMapMoved(false);
   }
+  
+  Future<Style> fetchStyle() =>
+      StyleReader(uri: 'https://api.tomtom.com/style/2/custom/style/dG9tdG9tQEBAQU1MSkFRZ1QyNjU0NU9WODs0OWFjMTBhMi0yODM5LTQ4NjItYjczMi01NGEwN2JiYTI0Y2I=/drafts/0.json?key={key}',
+      apiKey: const String.fromEnvironment('TOMTOM_API_KEY')).read();
 
   @override
   Widget build(BuildContext context) {
@@ -103,9 +116,8 @@ class _VisitsMapItemState extends ConsumerState<VisitsMapItem> {
             notifier.setIsMapMoved(true);
           }),
           children: [
-            TileLayer(
-              urlTemplate: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
-            ),
+            if (mapStyle != null)
+              VectorTileLayer(tileProviders: mapStyle!.providers, theme: mapStyle!.theme),
             PolylineLayer(polylines: [
               Polyline(
                   points: points,

--- a/application/lib/shared/component/filled_chip_theme.dart
+++ b/application/lib/shared/component/filled_chip_theme.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 class FilledChipTheme extends StatelessWidget {
-
   final Widget _child;
 
   const FilledChipTheme({super.key, required Widget child}) : _child = child;
@@ -12,28 +11,28 @@ class FilledChipTheme extends StatelessWidget {
     final textTheme = Theme.of(context).textTheme;
 
     return Theme(
-      data: Theme.of(context).copyWith(
-        chipTheme: ChipThemeData(
-            labelStyle: TextStyle(
-              color: WidgetStateColor.resolveWith((states) {
-                if (states.contains(WidgetState.selected)) {
-                  return colorScheme.onPrimary;
-                }
-                return colorScheme.primary;
-              }),
-              fontWeight: FontWeight.w600,
-            ),
-            secondaryLabelStyle: TextStyle(
-              color: colorScheme.onPrimary,
-              fontWeight: FontWeight.w600,
-            ),
-            selectedColor: colorScheme.primary,
-            checkmarkColor: colorScheme.onPrimary,
-            backgroundColor: colorScheme.primaryContainer,
-            labelPadding: const EdgeInsets.symmetric(horizontal: 4.0),
-            side: BorderSide.none,
-            padding: const EdgeInsets.all(10.0)),
-      ),
-      child: _child);
+        data: Theme.of(context).copyWith(
+          chipTheme: ChipThemeData(
+              labelStyle: TextStyle(
+                color: WidgetStateColor.resolveWith((states) {
+                  if (states.contains(WidgetState.selected)) {
+                    return colorScheme.onPrimary;
+                  }
+                  return colorScheme.primary;
+                }),
+                fontWeight: FontWeight.w600,
+              ),
+              secondaryLabelStyle: TextStyle(
+                color: colorScheme.onPrimary,
+                fontWeight: FontWeight.w600,
+              ),
+              selectedColor: colorScheme.primary,
+              checkmarkColor: colorScheme.onPrimary,
+              backgroundColor: colorScheme.primaryContainer,
+              labelPadding: const EdgeInsets.symmetric(horizontal: 4.0),
+              side: BorderSide.none,
+              padding: const EdgeInsets.all(10.0)),
+        ),
+        child: _child);
   }
 }

--- a/application/lib/shared/model/place_model.dart
+++ b/application/lib/shared/model/place_model.dart
@@ -6,7 +6,6 @@ part 'place_model.g.dart';
 
 @freezed
 class PlaceModel with _$PlaceModel {
-
   const factory PlaceModel({
     required int id,
     required String name,
@@ -17,12 +16,10 @@ class PlaceModel with _$PlaceModel {
 
   factory PlaceModel.fromJson(Map<String, dynamic> json) =>
       _$PlaceModelFromJson(json);
-
 }
 
 @freezed
 class PlaceCoordinates with _$PlaceCoordinates {
-
   const factory PlaceCoordinates({
     required double longitude,
     required double latitude,
@@ -30,18 +27,14 @@ class PlaceCoordinates with _$PlaceCoordinates {
 
   factory PlaceCoordinates.fromJson(Map<String, dynamic> json) =>
       _$PlaceCoordinatesFromJson(json);
-
 }
 
 @freezed
 class PlaceAddress with _$PlaceAddress {
-
   const PlaceAddress._();
 
-  const factory PlaceAddress({
-    required String lotNumber,
-    required String road
-  }) = _PlaceAddress;
+  const factory PlaceAddress(
+      {required String lotNumber, required String road}) = _PlaceAddress;
 
   factory PlaceAddress.fromJson(Map<String, dynamic> json) =>
       _$PlaceAddressFromJson(json);
@@ -50,9 +43,7 @@ class PlaceAddress with _$PlaceAddress {
     if (road.isNotEmpty) return road;
     return lotNumber;
   }
-
 }
-
 
 enum PlaceCategoryType {
   nature(Icons.nature_people),
@@ -67,4 +58,7 @@ enum PlaceCategoryType {
 
   const PlaceCategoryType(this.iconData);
 
+  static List<PlaceCategoryType> pois() {
+    return [nature, tourism, culture, commerce, transport];
+  }
 }

--- a/application/lib/shared/theme/my_fab_theme.dart
+++ b/application/lib/shared/theme/my_fab_theme.dart
@@ -11,7 +11,7 @@ class MyFabTheme extends StatelessWidget {
 
     final themeData = Theme.of(context).copyWith(
         floatingActionButtonTheme: FloatingActionButtonThemeData(
-      shape: CircleBorder(side: BorderSide(color: colorScheme.primaryFixed)),
+      shape: CircleBorder(side: BorderSide(color: colorScheme.primaryFixedDim)),
       elevation: 0.0,
       foregroundColor: colorScheme.primary,
       backgroundColor: colorScheme.primaryContainer,

--- a/application/pubspec.lock
+++ b/application/pubspec.lock
@@ -318,6 +318,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.2"
+  executor_lib:
+    dependency: transitive
+    description:
+      name: executor_lib
+      sha256: "544889daa5726462657dab6410b75f2f8e3a77479d85b307a25c346e243bc38e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   fake_async:
     dependency: transitive
     description:
@@ -818,6 +826,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  protobuf:
+    dependency: transitive
+    description:
+      name: protobuf
+      sha256: "68645b24e0716782e58948f8467fd42a880f255096a821f9e7d0ec625b00c84d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   pub_semver:
     dependency: transitive
     description:
@@ -1111,6 +1127,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.0"
+  vector_map_tiles:
+    dependency: "direct main"
+    description:
+      name: vector_map_tiles
+      sha256: "4dc9243195c1a49c7be82cc1caed0d300242bb94381752af5f6868d9d1404e25"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
   vector_math:
     dependency: transitive
     description:
@@ -1119,6 +1143,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vector_tile:
+    dependency: transitive
+    description:
+      name: vector_tile
+      sha256: "3adb04426f3aebefce56f3fdf8ab2e23cc9f7d5b06ff8ca33ae87e3a1e441874"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
+  vector_tile_renderer:
+    dependency: transitive
+    description:
+      name: vector_tile_renderer
+      sha256: b58fa02b472ced87de00de2b4d5837576239bddb21b562481f25bde39bd117ae
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.0"
   visibility_detector:
     dependency: "direct main"
     description:

--- a/application/pubspec.yaml
+++ b/application/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   visibility_detector: ^0.4.0+2
   infinite_scroll_pagination: ^4.0.0
   flutter_staggered_grid_view: ^0.7.0
+  vector_map_tiles: ^8.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> Ex. close #이슈 번호, #이슈 번호

#12 


## 📝 작업 내용
> 작업한 내용을 간략히 설명해 주세요.

### 지도 뷰 구현
관광 명소 ListView에 Toggle Button 을 사용해 뷰 타입을 선택하고, AnimatedSwitcher 로 View를 변경하도록 구현하였습니다.

지도 뷰에서 Card에 관광 명소 목록을 표시하고, 옆으로 넘기면서 장소를 선택하고 지도를 이동합니다. 여기에서 무한 스크롤을 구현하기 위해 카드를 하나 더 넣고, 카드가 100% 표시될 때 (지금 생각하면 index 검사가 나을 듯 합니다) 추가로 데이터를 불러옵니다.

### 지도 스타일 변경

현재의 Map 라이브러리는 외부 제공자에 지도 타일을 불러오는 방식입니다. 지금 쓰는 OpenStreetMap은 별도 스타일을 지정하지 않아, Map 타일의 스타일을 변경해 제공하는 3rd party 서비스가 필요했습니다.

여기서 MapBox와 TomTom 서비스를 비교했습니다. 둘다 무료 서비스지만, TomTom이 일일 할당량이 높고 신용카드 정보를 요구하지 않아 후자를 선택했습니다.

<br/>

## ✅ 작업 결과
> 작업 내용 Notion 링크, 혹은 이미지를 첨부해 주세요.

![Simulator Screen Recording - iPhone 15 Pro Max - 2024-11-06 at 20 11 26](https://github.com/user-attachments/assets/a288a296-940d-43bf-ae6a-fdee2d7c8015)

<br/>

## 💬 추가 사항 (선택)
> 추가로 기재할 사항이 있으면 기재해 주세요.

### 관광지/여행 목록 UI 개선

<img src="https://github.com/user-attachments/assets/1d365fa5-974c-45c7-bc7c-fb5c1f20b003" width="240px" />

현재 위처럼 단순히 관광 명소, 식당/카페, 숙소 버튼을 배치했는데, 이를 각각 Top5 미리보기로 개선하려고 합니다.
또한 여행 추천 목록 또한 같이 배치하는게 맞아 보입니다.

### 명소 지도/리스트 뷰 위젯 캐싱
현재는 변경 시 상태가 초기화 되는데, 추후 두 위젯을 캐싱 처리해 사용자 경험을 개선할 예정입니다.

