### PR TITLE
Feature(#20): 여행 계획 지도 뷰 구현

### DIFF
--- a/application/assets/translations/en.yaml
+++ b/application/assets/translations/en.yaml
@@ -173,7 +173,7 @@ enum:
       rating: Top Rated
       popularity: Most Popular
 
-  PlaceViewType:
+  ViewType:
     name: Type of view
     values:
       map: Map

--- a/application/assets/translations/ko.yaml
+++ b/application/assets/translations/ko.yaml
@@ -179,7 +179,7 @@ enum:
       rating: 평점 높은 순
       popularity: 많이 방문한 순
 
-  PlaceViewType:
+  ViewType:
     name: 보기 유형
     values:
       map: 지도

--- a/application/lib/domain/place/place_model.dart
+++ b/application/lib/domain/place/place_model.dart
@@ -1,3 +1,4 @@
+import 'package:application_new/shared/interfaces/IconDataProvidable.dart';
 import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -52,7 +53,7 @@ class PlaceAddress with _$PlaceAddress {
   }
 }
 
-enum PlaceCategoryType {
+enum PlaceCategoryType implements IconDataEnum {
   nature(Icons.nature_people),
   tourism(Icons.tour),
   culture(Icons.theater_comedy),
@@ -61,6 +62,7 @@ enum PlaceCategoryType {
   dining(Icons.dining),
   lodging(Icons.hotel);
 
+  @override
   final IconData iconData;
 
   const PlaceCategoryType(this.iconData);

--- a/application/lib/feature/travel_plan/page/travel_plan_manage/component/travel_plan_list_item.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_manage/component/travel_plan_list_item.dart
@@ -112,7 +112,7 @@ class _TravelPlanListITemState extends ConsumerState<TravelPlanListItem> {
                 ),
                 const SizedBox(height: 8.0),
                 Wrap(
-                  spacing: 6.0,
+                  spacing: 4.0,
                   children: [
                     OutlinedIconButton(
                         onPressed: () {},

--- a/application/lib/feature/travel_plan/page/travel_plan_manage/page/places_map_view.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_manage/page/places_map_view.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:application_new/domain/place/place_model.dart';
 import 'package:application_new/feature/travel_read/components/place_marker_item.dart';
+import 'package:application_new/shared/component/tonal_filled_icon_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 
@@ -24,7 +25,7 @@ class _PlacesMapViewState extends State<PlacesMapView> {
 
   Style? style;
 
-  static const double markerRadius = 26.0;
+  static const double markerRadius = 32.0;
 
   PlaceModel? selectedPlace;
 
@@ -36,6 +37,9 @@ class _PlacesMapViewState extends State<PlacesMapView> {
       ).read();
 
   Completer<bool> mapReadyCompleter = Completer();
+
+
+  bool isMoving = false;
 
   @override
   void initState() {
@@ -53,7 +57,9 @@ class _PlacesMapViewState extends State<PlacesMapView> {
           width: markerRadius,
           height: markerRadius,
           point: LatLng(latitude, longitude),
-          child: PlaceMarkerItem(place: place, isSelected: isSelected));
+          child: PlaceMarkerItem(
+              radius: markerRadius,
+              place: place, isSelected: isSelected));
     }).toList();
   }
 
@@ -69,10 +75,13 @@ class _PlacesMapViewState extends State<PlacesMapView> {
     final ThemeData(:textTheme, :colorScheme) = Theme.of(context);
 
     final topPadding =
-        MediaQuery.of(context).padding.top + (padding?.top ?? 0.0);
+        MediaQuery.of(context).padding.top + (padding?.top ?? 0.0) + markerRadius;
+
     markers = _buildMarkers(widget.places);
-    mapReadyCompleter.future.then((_) {
-      return mapController.fitCamera(CameraFit.coordinates(
+
+    mapReadyCompleter.future.then((_) async {
+
+      mapController.fitCamera(CameraFit.coordinates(
           maxZoom: 12.0,
           padding: EdgeInsets.fromLTRB(
             markerRadius + 24.0 + (padding?.left ?? 0),
@@ -104,18 +113,23 @@ class _PlacesMapViewState extends State<PlacesMapView> {
             child: Wrap(
               direction: Axis.vertical,
               children: [
-                IconButton.filledTonal(
+                TonalFilledIconButton(
+                    iconSize: 21.0,
                     onPressed: () {
                       final MapCamera(:center, :zoom) = mapController.camera;
                       mapController.move(center, zoom + 1.0);
                     },
                     icon: Icon(Icons.add, color: colorScheme.primary)),
-                IconButton.filledTonal(
+                TonalFilledIconButton(
+                    iconSize: 21.0,
                     onPressed: () {
                       final MapCamera(:center, :zoom) = mapController.camera;
                       mapController.move(center, zoom - 1.0);
                     },
-                    icon: Icon(Icons.remove, color: colorScheme.primary,)),
+                    icon: Icon(
+                      Icons.remove,
+                      color: colorScheme.primary,
+                    )),
               ],
             ))
       ],

--- a/application/lib/feature/travel_plan/page/travel_plan_manage/page/travel_plan_date_range_view.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_manage/page/travel_plan_date_range_view.dart
@@ -1,18 +1,19 @@
-import 'package:application_new/common/util/date_util.dart';
 import 'package:application_new/domain/travel/travel_model.dart';
 import 'package:application_new/feature/travel_plan/page/travel_plan_manage/component/travel_date_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class TravelPlanDateView extends ConsumerStatefulWidget {
+class TravelDateRangeView extends ConsumerStatefulWidget {
   final TravelModel travel;
   final DateTime? selectedDate;
   final void Function(DateTime date) onChangeDate;
+  final Widget Function(TravelDateItem item, int index)? builder;
 
-  const TravelPlanDateView({
+  const TravelDateRangeView({
     super.key,
     required this.travel,
     required this.onChangeDate,
+    this.builder,
     this.selectedDate,
   });
 
@@ -20,37 +21,7 @@ class TravelPlanDateView extends ConsumerStatefulWidget {
   ConsumerState createState() => _TravelPlanDateViewState();
 }
 
-class _TravelPlanDateViewState extends ConsumerState<TravelPlanDateView> {
-  final ScrollController scrollController = ScrollController();
-  static const dateWidgetWidth = 48.0;
-
-  late final int daysOfMonth;
-  late final DateTime firstDayOfMonth;
-
-  late final DateTimeRange travelDateRange;
-
-  @override
-  void initState() {
-    super.initState();
-
-    final startedOn = widget.travel.startedOn;
-
-    firstDayOfMonth = DateTime(startedOn.year, startedOn.month);
-    daysOfMonth = DateUtils.getDaysInMonth(startedOn.year, startedOn.month);
-
-    Future.microtask(() {
-      final initialOffset =
-          startedOn.difference(firstDayOfMonth).inDays * dateWidgetWidth;
-
-      scrollController.jumpTo(initialOffset);
-    });
-  }
-
-  @override
-  void dispose() {
-    scrollController.dispose();
-    super.dispose();
-  }
+class _TravelPlanDateViewState extends ConsumerState<TravelDateRangeView> {
 
   @override
   Widget build(BuildContext context) {
@@ -61,17 +32,18 @@ class _TravelPlanDateViewState extends ConsumerState<TravelPlanDateView> {
             .duration
             .inDays;
 
+    final builder = widget.builder ?? (TravelDateItem item, int index) => item;
+
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
-      controller: scrollController,
       child: Row(mainAxisAlignment: MainAxisAlignment.start, children: [
         const SizedBox(width: 16.0),
         for (int i = 0; i < daysOfTravel; i++) ...[
-          TravelDateItem(
+          builder(TravelDateItem(
               dayOfTravel: i,
               travel: travel,
               selectedDate: widget.selectedDate,
-              onChangeDate: widget.onChangeDate),
+              onChangeDate: widget.onChangeDate), i),
           const SizedBox(width: 8.0),
         ],
         const SizedBox(width: 16.0),

--- a/application/lib/feature/travel_plan/page/travel_plan_manage/page/travel_plan_date_range_view.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_manage/page/travel_plan_date_range_view.dart
@@ -3,7 +3,8 @@ import 'package:application_new/feature/travel_plan/page/travel_plan_manage/comp
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class TravelDateRangeView extends ConsumerStatefulWidget {
+
+class TravelDateRangeView extends ConsumerWidget {
   final TravelModel travel;
   final DateTime? selectedDate;
   final void Function(DateTime date) onChangeDate;
@@ -18,36 +19,38 @@ class TravelDateRangeView extends ConsumerStatefulWidget {
   });
 
   @override
-  ConsumerState createState() => _TravelPlanDateViewState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
 
-class _TravelPlanDateViewState extends ConsumerState<TravelDateRangeView> {
-
-  @override
-  Widget build(BuildContext context) {
-    final travel = widget.travel;
+    final ThemeData(:textTheme, :colorScheme) = Theme.of(context);
 
     final daysOfTravel =
         DateTimeRange(start: travel.startedOn, end: travel.endedOn)
             .duration
             .inDays;
 
-    final builder = widget.builder ?? (TravelDateItem item, int index) => item;
+    final builder = this.builder ?? (TravelDateItem item, int index) => item;
 
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: Row(mainAxisAlignment: MainAxisAlignment.start, children: [
-        const SizedBox(width: 16.0),
-        for (int i = 0; i < daysOfTravel; i++) ...[
-          builder(TravelDateItem(
-              dayOfTravel: i,
-              travel: travel,
-              selectedDate: widget.selectedDate,
-              onChangeDate: widget.onChangeDate), i),
-          const SizedBox(width: 8.0),
-        ],
-        const SizedBox(width: 16.0),
-      ]),
+    return Container(
+      width: double.maxFinite,
+      padding: const EdgeInsets.only(top: 16.0, bottom: 4.0),
+      decoration: BoxDecoration(
+          border: Border(
+              bottom: BorderSide(color: colorScheme.surfaceContainerHigh))),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(mainAxisAlignment: MainAxisAlignment.start, children: [
+          const SizedBox(width: 16.0),
+          for (int i = 0; i < daysOfTravel; i++) ...[
+            builder(TravelDateItem(
+                dayOfTravel: i,
+                travel: travel,
+                selectedDate: selectedDate,
+                onChangeDate: onChangeDate), i),
+            const SizedBox(width: 8.0),
+          ],
+          const SizedBox(width: 16.0),
+        ]),
+      ),
     );
   }
 }

--- a/application/lib/feature/travel_plan/page/travel_plan_manage/page/travel_plan_manage_page.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_manage/page/travel_plan_manage_page.dart
@@ -58,6 +58,7 @@ class TravelPlanManagePage extends ConsumerWidget {
               height: (bodyHeight - dragHandleHeight - 81.0) *
                   TravelPlanManage.mapHeightRatios[mapHeightLevel],
               child: PlacesMapView(
+                usePolyline: true,
                 places: selectedVisitPlaces.map((e) => e.place).toList(),
               ),
             ),

--- a/application/lib/feature/travel_plan/page/travel_plan_manage/page/travel_plan_mange_list_view.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_manage/page/travel_plan_mange_list_view.dart
@@ -5,7 +5,7 @@ import 'package:application_new/domain/travel_visit/travel_visit_model.dart';
 import 'package:application_new/feature/travel_plan/page/travel_plan_manage/component/travel_date_item.dart';
 import 'package:application_new/feature/travel_plan/page/travel_plan_manage/component/travel_plan_list_drag_item.dart';
 import 'package:application_new/feature/travel_plan/page/travel_plan_manage/component/travel_plan_list_item.dart';
-import 'package:application_new/feature/travel_plan/page/travel_plan_manage/page/travel_plan_date_view.dart';
+import 'package:application_new/feature/travel_plan/page/travel_plan_manage/page/travel_plan_date_range_view.dart';
 import 'package:application_new/feature/travel_plan/page/travel_plan_manage/provider/travel_plan_manage_provider.dart';
 import 'package:application_new/shared/component/fixed_header_delegate.dart';
 import 'package:flutter/material.dart';
@@ -63,25 +63,16 @@ class _TravelPlanMangeListViewState
           decoration: BoxDecoration(
               border: Border(
                   bottom: BorderSide(color: colorScheme.surfaceContainerHigh))),
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Row(mainAxisAlignment: MainAxisAlignment.start, children: [
-              const SizedBox(width: 16.0),
-              for (int i = 0; i < daysOfTravel; i++) ...[
-                DragTarget(
-                    onMove: (detail) => widget
-                        .onChangeDate(travel.startedOn.add(Duration(days: i))),
-                    builder: (context, candidateData, rejectedData) =>
-                        TravelDateItem(
-                            dayOfTravel: i,
-                            travel: travel,
-                            selectedDate: widget.selectedDate,
-                            onChangeDate: widget.onChangeDate)),
-                const SizedBox(width: 8.0),
-              ],
-              const SizedBox(width: 16.0),
-            ]),
-          ),
+          child: TravelDateRangeView(
+              travel: travel,
+              onChangeDate: widget.onChangeDate,
+              selectedDate: widget.selectedDate,
+              builder: (item, index) {
+                return DragTarget(
+                    onMove: (detail) => widget.onChangeDate(
+                        travel.startedOn.add(Duration(days: index))),
+                    builder: (context, candidateData, rejectedData) => item);
+              }),
         ),
         Expanded(
           child: Stack(

--- a/application/lib/feature/travel_plan/page/travel_plan_manage/page/travel_plan_mange_list_view.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_manage/page/travel_plan_mange_list_view.dart
@@ -55,153 +55,130 @@ class _TravelPlanMangeListViewState
       scrollController.jumpTo(0.0);
     });
 
-    return Column(
+    return Stack(
       children: [
-        Container(
-          width: double.maxFinite,
-          padding: const EdgeInsets.only(top: 16.0, bottom: 4.0),
-          decoration: BoxDecoration(
-              border: Border(
-                  bottom: BorderSide(color: colorScheme.surfaceContainerHigh))),
-          child: TravelDateRangeView(
-              travel: travel,
-              onChangeDate: widget.onChangeDate,
-              selectedDate: widget.selectedDate,
-              builder: (item, index) {
-                return DragTarget(
-                    onMove: (detail) => widget.onChangeDate(
-                        travel.startedOn.add(Duration(days: index))),
-                    builder: (context, candidateData, rejectedData) => item);
-              }),
-        ),
-        Expanded(
-          child: Stack(
-            children: [
-              Positioned.fill(
-                  child: CustomScrollView(
-                      physics: const ClampingScrollPhysics(),
-                      controller: scrollController,
-                      slivers: [
-                    const SliverToBoxAdapter(child: SizedBox(height: 48.0)),
-                    SliverList.builder(
-                        itemCount: visitPlaces.length,
-                        itemBuilder: (context, index) {
-                          final visitPlace = visitPlaces[index];
+        Positioned.fill(
+            child: CustomScrollView(
+                physics: const ClampingScrollPhysics(),
+                controller: scrollController,
+                slivers: [
+              const SliverToBoxAdapter(child: SizedBox(height: 48.0)),
+              SliverList.builder(
+                  itemCount: visitPlaces.length,
+                  itemBuilder: (context, index) {
+                    final visitPlace = visitPlaces[index];
 
-                          return DragTarget<TravelVisitWithPlaceModel>(
-                              onAcceptWithDetails: (detail) => ref
-                                  .read(travelPlanManageProvider(travel.id)
-                                      .notifier)
-                                  .move(detail.data,
-                                      visitPlace.visit.orderOfVisit),
-                              builder: (context, candidateData, rejectedData) {
-                                return Column(
-                                  children: [
-                                    if (candidateData.isNotEmpty)
-                                      Opacity(
-                                          opacity: 0.5,
-                                          child: TravelPlanListItem(
-                                              order: index,
-                                              visitPlace:
-                                                  candidateData.first!)),
-                                    TravelPlanListItem(
-                                        onDelete: () => ref
-                                            .read(travelPlanManageProvider(
-                                                    travel.id)
-                                                .notifier)
-                                            .delete(visitPlace),
-                                        order: index,
-                                        visitPlace: visitPlace),
-                                  ],
-                                );
-                              });
-                        }),
-                    SliverFillRemaining(
-                      hasScrollBody: false,
-                      child: DragTarget<TravelVisitWithPlaceModel>(
-                          onAcceptWithDetails: (detail) {
-                        var lastVisit = visitPlaces.lastOrNull?.visit;
-                        ref
-                            .read(travelPlanManageProvider(travel.id).notifier)
+                    return DragTarget<TravelVisitWithPlaceModel>(
+                        onAcceptWithDetails: (detail) => ref
+                            .read(travelPlanManageProvider(travel.id)
+                                .notifier)
                             .move(detail.data,
-                                (lastVisit?.orderOfVisit ?? -1) + 1);
-                      }, builder: (context, candidateData, rejectedData) {
-                        return Column(
-                          children: [
-                            if (candidateData.isNotEmpty)
-                              Opacity(
-                                  opacity: 0.5,
-                                  child: TravelPlanListItem(
-                                      order: 0,
-                                      visitPlace: candidateData.first!)),
-                            Expanded(
-                              child: Container(
-                                width: double.maxFinite,
-                                constraints:
-                                    const BoxConstraints(minHeight: 128.0),
-                                child: Row(
+                                visitPlace.visit.orderOfVisit),
+                        builder: (context, candidateData, rejectedData) {
+                          return Column(
+                            children: [
+                              if (candidateData.isNotEmpty)
+                                Opacity(
+                                    opacity: 0.5,
+                                    child: TravelPlanListItem(
+                                        order: index,
+                                        visitPlace:
+                                            candidateData.first!)),
+                              TravelPlanListItem(
+                                  onDelete: () => ref
+                                      .read(travelPlanManageProvider(
+                                              travel.id)
+                                          .notifier)
+                                      .delete(visitPlace),
+                                  order: index,
+                                  visitPlace: visitPlace),
+                            ],
+                          );
+                        });
+                  }),
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: DragTarget<TravelVisitWithPlaceModel>(
+                    onAcceptWithDetails: (detail) {
+                  var lastVisit = visitPlaces.lastOrNull?.visit;
+                  ref
+                      .read(travelPlanManageProvider(travel.id).notifier)
+                      .move(detail.data,
+                          (lastVisit?.orderOfVisit ?? -1) + 1);
+                }, builder: (context, candidateData, rejectedData) {
+                  return Column(
+                    children: [
+                      if (candidateData.isNotEmpty)
+                        Opacity(
+                            opacity: 0.5,
+                            child: TravelPlanListItem(
+                                order: 0,
+                                visitPlace: candidateData.first!)),
+                      Expanded(
+                        child: Container(
+                          width: double.maxFinite,
+                          constraints:
+                              const BoxConstraints(minHeight: 128.0),
+                          child: Row(
+                            children: [
+                              const SizedBox(width: 24.0),
+                              SizedBox(
+                                width: 32.0,
+                                child: Column(
                                   children: [
-                                    const SizedBox(width: 24.0),
-                                    SizedBox(
-                                      width: 32.0,
-                                      child: Column(
-                                        children: [
-                                          if (visitPlaces.isEmpty)
-                                            CircleAvatar(
-                                              radius: 16.0,
-                                              child: Icon(
-                                                  Icons
-                                                      .add_location_alt_outlined,
-                                                  color: colorScheme.primary,
-                                                  size: 18.0),
-                                            ),
-                                          Expanded(
-                                            child: Container(
-                                              width: 1.0,
-                                              color:
-                                                  colorScheme.primaryContainer,
-                                            ),
-                                          ),
-                                        ],
+                                    if (visitPlaces.isEmpty)
+                                      CircleAvatar(
+                                        radius: 16.0,
+                                        child: Icon(
+                                            Icons
+                                                .add_location_alt_outlined,
+                                            color: colorScheme.primary,
+                                            size: 18.0),
                                       ),
-                                    ),
                                     Expanded(
-                                      child: Container(),
+                                      child: Container(
+                                        width: 1.0,
+                                        color:
+                                            colorScheme.primaryContainer,
+                                      ),
                                     ),
                                   ],
                                 ),
                               ),
-                            )
-                          ],
-                        );
-                      }),
-                    )
-                  ])),
-              Align(
-                alignment: Alignment.topCenter,
-                child: DragTarget<TravelVisitWithPlaceModel>(
-                  builder: (context, accepted, rejected) => Container(
-                    height: 40,
-                    width: double.infinity,
-                    color: Colors.transparent,
-                  ),
-                  onMove: (detail) => scrollUp(),
-                ),
-              ),
-              Align(
-                alignment: Alignment.bottomCenter,
-                child: DragTarget<TravelVisitWithPlaceModel>(
-                  builder: (context, accepted, rejected) => Container(
-                    height: 40,
-                    width: double.infinity,
-                    color: Colors.transparent,
-                  ),
-                  onMove: (detail) => scrollDown(),
-                ),
+                              Expanded(
+                                child: Container(),
+                              ),
+                            ],
+                          ),
+                        ),
+                      )
+                    ],
+                  );
+                }),
               )
-            ],
+            ])),
+        Align(
+          alignment: Alignment.topCenter,
+          child: DragTarget<TravelVisitWithPlaceModel>(
+            builder: (context, accepted, rejected) => Container(
+              height: 40,
+              width: double.infinity,
+              color: Colors.transparent,
+            ),
+            onMove: (detail) => scrollUp(),
           ),
         ),
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: DragTarget<TravelVisitWithPlaceModel>(
+            builder: (context, accepted, rejected) => Container(
+              height: 40,
+              width: double.infinity,
+              color: Colors.transparent,
+            ),
+            onMove: (detail) => scrollDown(),
+          ),
+        )
       ],
     );
   }

--- a/application/lib/feature/travel_plan/page/travel_plan_manage/provider/travel_plan_manage_provider.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_manage/provider/travel_plan_manage_provider.dart
@@ -13,6 +13,9 @@ part 'travel_plan_manage_provider.g.dart';
 
 @riverpod
 class TravelPlanManage extends _$TravelPlanManage {
+
+  static const List<double> mapHeightRatios = [0.0, 0.4, 1.0];
+
   @override
   TravelPlanManageState? build(int travelId) {
     _init();
@@ -39,6 +42,36 @@ class TravelPlanManage extends _$TravelPlanManage {
   void selectDate(DateTime date) {
     if (state?.selectedDate == date) return;
     state = state?.copyWith(selectedDate: date);
+  }
+
+  void endAnimating() {
+    if (state == null || !state!.isAnimating) return;
+
+    state = state!.copyWith(isAnimating: false);
+  }
+
+  void updateMapHeight(double dy) {
+
+    if (state == null || state!.isAnimating) return;
+
+    final isScrollingDown = dy > 0.0;
+    final mapHeightLevel = state!.mapHeightLevel;
+
+    if (isScrollingDown) {
+      if (mapHeightLevel + 1 == mapHeightRatios.length) return;
+
+      state = state!.copyWith(
+        isAnimating: true,
+        mapHeightLevel: mapHeightLevel + 1
+      );
+    } else {
+      if (mapHeightLevel == 0) return;
+
+      state = state!.copyWith(
+          isAnimating: true,
+          mapHeightLevel: mapHeightLevel - 1
+      );
+    }
   }
 
   Future<void> move(TravelVisitWithPlaceModel from, int order) async {
@@ -92,4 +125,7 @@ class TravelPlanManage extends _$TravelPlanManage {
             visit: visit,
             place: await ref.watch(placeProvider(visit.placeId).future))));
   }
+
+
+
 }

--- a/application/lib/feature/travel_plan/page/travel_plan_manage/provider/travel_plan_manage_provider.g.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_manage/provider/travel_plan_manage_provider.g.dart
@@ -6,7 +6,7 @@ part of 'travel_plan_manage_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$travelPlanManageHash() => r'18e2ac7e82c059958a3efd0769aee98180fdef15';
+String _$travelPlanManageHash() => r'b98ad81f3f67eb2564d92f26b10f68f06f03725c';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/application/lib/feature/travel_plan/page/travel_plan_manage/provider/travel_plan_manage_state.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_manage/provider/travel_plan_manage_state.dart
@@ -10,5 +10,7 @@ class TravelPlanManageState with _$TravelPlanManageState {
     required TravelModel travel,
     required List<TravelVisitWithPlaceModel> visitPlaces,
     required DateTime selectedDate,
+    @Default(1) int mapHeightLevel,
+    @Default(false) bool isAnimating,
   }) = _TravelPlanManageState;
 }

--- a/application/lib/feature/travel_plan/page/travel_plan_manage/provider/travel_plan_manage_state.freezed.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_manage/provider/travel_plan_manage_state.freezed.dart
@@ -20,6 +20,8 @@ mixin _$TravelPlanManageState {
   List<TravelVisitWithPlaceModel> get visitPlaces =>
       throw _privateConstructorUsedError;
   DateTime get selectedDate => throw _privateConstructorUsedError;
+  int get mapHeightLevel => throw _privateConstructorUsedError;
+  bool get isAnimating => throw _privateConstructorUsedError;
 
   /// Create a copy of TravelPlanManageState
   /// with the given fields replaced by the non-null parameter values.
@@ -37,7 +39,9 @@ abstract class $TravelPlanManageStateCopyWith<$Res> {
   $Res call(
       {TravelModel travel,
       List<TravelVisitWithPlaceModel> visitPlaces,
-      DateTime selectedDate});
+      DateTime selectedDate,
+      int mapHeightLevel,
+      bool isAnimating});
 
   $TravelModelCopyWith<$Res> get travel;
 }
@@ -61,6 +65,8 @@ class _$TravelPlanManageStateCopyWithImpl<$Res,
     Object? travel = null,
     Object? visitPlaces = null,
     Object? selectedDate = null,
+    Object? mapHeightLevel = null,
+    Object? isAnimating = null,
   }) {
     return _then(_value.copyWith(
       travel: null == travel
@@ -75,6 +81,14 @@ class _$TravelPlanManageStateCopyWithImpl<$Res,
           ? _value.selectedDate
           : selectedDate // ignore: cast_nullable_to_non_nullable
               as DateTime,
+      mapHeightLevel: null == mapHeightLevel
+          ? _value.mapHeightLevel
+          : mapHeightLevel // ignore: cast_nullable_to_non_nullable
+              as int,
+      isAnimating: null == isAnimating
+          ? _value.isAnimating
+          : isAnimating // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 
@@ -101,7 +115,9 @@ abstract class _$$TravelPlanManageStateImplCopyWith<$Res>
   $Res call(
       {TravelModel travel,
       List<TravelVisitWithPlaceModel> visitPlaces,
-      DateTime selectedDate});
+      DateTime selectedDate,
+      int mapHeightLevel,
+      bool isAnimating});
 
   @override
   $TravelModelCopyWith<$Res> get travel;
@@ -124,6 +140,8 @@ class __$$TravelPlanManageStateImplCopyWithImpl<$Res>
     Object? travel = null,
     Object? visitPlaces = null,
     Object? selectedDate = null,
+    Object? mapHeightLevel = null,
+    Object? isAnimating = null,
   }) {
     return _then(_$TravelPlanManageStateImpl(
       travel: null == travel
@@ -138,6 +156,14 @@ class __$$TravelPlanManageStateImplCopyWithImpl<$Res>
           ? _value.selectedDate
           : selectedDate // ignore: cast_nullable_to_non_nullable
               as DateTime,
+      mapHeightLevel: null == mapHeightLevel
+          ? _value.mapHeightLevel
+          : mapHeightLevel // ignore: cast_nullable_to_non_nullable
+              as int,
+      isAnimating: null == isAnimating
+          ? _value.isAnimating
+          : isAnimating // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -148,7 +174,9 @@ class _$TravelPlanManageStateImpl implements _TravelPlanManageState {
   const _$TravelPlanManageStateImpl(
       {required this.travel,
       required final List<TravelVisitWithPlaceModel> visitPlaces,
-      required this.selectedDate})
+      required this.selectedDate,
+      this.mapHeightLevel = 1,
+      this.isAnimating = false})
       : _visitPlaces = visitPlaces;
 
   @override
@@ -163,10 +191,16 @@ class _$TravelPlanManageStateImpl implements _TravelPlanManageState {
 
   @override
   final DateTime selectedDate;
+  @override
+  @JsonKey()
+  final int mapHeightLevel;
+  @override
+  @JsonKey()
+  final bool isAnimating;
 
   @override
   String toString() {
-    return 'TravelPlanManageState(travel: $travel, visitPlaces: $visitPlaces, selectedDate: $selectedDate)';
+    return 'TravelPlanManageState(travel: $travel, visitPlaces: $visitPlaces, selectedDate: $selectedDate, mapHeightLevel: $mapHeightLevel, isAnimating: $isAnimating)';
   }
 
   @override
@@ -178,12 +212,21 @@ class _$TravelPlanManageStateImpl implements _TravelPlanManageState {
             const DeepCollectionEquality()
                 .equals(other._visitPlaces, _visitPlaces) &&
             (identical(other.selectedDate, selectedDate) ||
-                other.selectedDate == selectedDate));
+                other.selectedDate == selectedDate) &&
+            (identical(other.mapHeightLevel, mapHeightLevel) ||
+                other.mapHeightLevel == mapHeightLevel) &&
+            (identical(other.isAnimating, isAnimating) ||
+                other.isAnimating == isAnimating));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, travel,
-      const DeepCollectionEquality().hash(_visitPlaces), selectedDate);
+  int get hashCode => Object.hash(
+      runtimeType,
+      travel,
+      const DeepCollectionEquality().hash(_visitPlaces),
+      selectedDate,
+      mapHeightLevel,
+      isAnimating);
 
   /// Create a copy of TravelPlanManageState
   /// with the given fields replaced by the non-null parameter values.
@@ -199,7 +242,9 @@ abstract class _TravelPlanManageState implements TravelPlanManageState {
   const factory _TravelPlanManageState(
       {required final TravelModel travel,
       required final List<TravelVisitWithPlaceModel> visitPlaces,
-      required final DateTime selectedDate}) = _$TravelPlanManageStateImpl;
+      required final DateTime selectedDate,
+      final int mapHeightLevel,
+      final bool isAnimating}) = _$TravelPlanManageStateImpl;
 
   @override
   TravelModel get travel;
@@ -207,6 +252,10 @@ abstract class _TravelPlanManageState implements TravelPlanManageState {
   List<TravelVisitWithPlaceModel> get visitPlaces;
   @override
   DateTime get selectedDate;
+  @override
+  int get mapHeightLevel;
+  @override
+  bool get isAnimating;
 
   /// Create a copy of TravelPlanManageState
   /// with the given fields replaced by the non-null parameter values.

--- a/application/lib/feature/travel_plan/page/travel_plan_recommend/page/city_place_pois/page/city_place_pois_page.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_recommend/page/city_place_pois/page/city_place_pois_page.dart
@@ -36,7 +36,7 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
 
   bool hasScrollDown = false;
   PlaceSortType sortType = PlaceSortType.rating;
-  PlaceViewType viewType = PlaceViewType.list;
+  ViewType viewType = ViewType.list;
 
   static const double scrollThreshold = 240.0;
 
@@ -118,9 +118,9 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
                 child: AnimatedSwitcher(
                     duration: const Duration(milliseconds: 300),
                     child: switch (viewType) {
-                      PlaceViewType.list =>
+                      ViewType.list =>
                         buildListView(state.travel, data, state.hasNextPage),
-                      PlaceViewType.map => buildMapView(data, bottomPadding,
+                      ViewType.map => buildMapView(data, bottomPadding,
                           state.placeMetrics, state.hasNextPage)
                     })),
             Positioned(
@@ -249,39 +249,34 @@ class _CityPlaceListPageState extends ConsumerState<CityPlacePoisPage> {
   Widget buildToggleViewButton() {
     final ThemeData(:textTheme, :colorScheme) = Theme.of(context);
 
-    return Container(
-        decoration: BoxDecoration(
-          color: colorScheme.surface,
-          borderRadius: BorderRadius.circular(12.0),
-        ),
-        child: ToggleButtons(
-            fillColor: colorScheme.primaryContainer,
-            borderColor: colorScheme.surfaceContainerHighest,
-            selectedBorderColor: colorScheme.primaryFixedDim,
-            borderRadius: BorderRadius.circular(12.0),
-            textStyle: const TextStyle(fontWeight: FontWeight.w600),
-            onPressed: (index) {
-              final viewType = PlaceViewType.values[index];
-              if (this.viewType == viewType) return;
+    return ToggleButtons(
+        fillColor: colorScheme.primaryContainer,
+        borderColor: colorScheme.surfaceContainerHighest,
+        selectedBorderColor: colorScheme.primaryFixedDim,
+        borderRadius: BorderRadius.circular(12.0),
+        textStyle: const TextStyle(fontWeight: FontWeight.w600),
+        onPressed: (index) {
+          final viewType = ViewType.values[index];
+          if (this.viewType == viewType) return;
 
-              hasScrollDown = false;
-              setState(() => this.viewType = viewType);
-            },
-            isSelected: PlaceViewType.values
-                .map((viewType) => viewType == this.viewType)
-                .toList(),
-            children: [
-              for (final viewType in PlaceViewType.values)
-                Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                    child: Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Icon(viewType.iconData, size: 18.0),
-                          const SizedBox(width: 8.0),
-                          Text(TranslationUtil.enumValue(viewType)),
-                        ])),
-            ]));
+          hasScrollDown = false;
+          setState(() => this.viewType = viewType);
+        },
+        isSelected: ViewType.values
+            .map((viewType) => viewType == this.viewType)
+            .toList(),
+        children: [
+          for (final viewType in ViewType.values)
+            Container(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(viewType.iconData, size: 18.0),
+                      const SizedBox(width: 8.0),
+                      Text(TranslationUtil.enumValue(viewType)),
+                    ])),
+        ]);
   }
 
   FilterChip buildFilterChip(PlaceCategoryType categoryType) {

--- a/application/lib/feature/travel_plan/page/travel_plan_recommend/page/city_place_pois/provider/city_place_map_provider.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_recommend/page/city_place_pois/provider/city_place_map_provider.dart
@@ -30,7 +30,7 @@ class CityPlaceMap extends _$CityPlaceMap {
           width: markerRadius,
           height: markerRadius,
           point: LatLng(latitude, longitude),
-          child: PlaceMarkerItem(place: place, isSelected: isSelected));
+          child: PlaceWithCategoryMarkerItem(place: place, isSelected: isSelected));
     }).toList();
   }
 

--- a/application/lib/feature/travel_plan/page/travel_plan_recommend/page/city_place_pois/provider/city_place_map_provider.g.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_recommend/page/city_place_pois/provider/city_place_map_provider.g.dart
@@ -6,7 +6,7 @@ part of 'city_place_map_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$cityPlaceMapHash() => r'32f4968d625a95e1946ec8b5a0311e114599c9d2';
+String _$cityPlaceMapHash() => r'86eec6a860103d9b779db91f6ba8ed81e190b74e';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/application/lib/feature/travel_plan/page/travel_plan_recommend/page/city_place_pois/provider/city_place_pois_state.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_recommend/page/city_place_pois/provider/city_place_pois_state.dart
@@ -1,6 +1,7 @@
 import 'package:application_new/domain/geography/geography_model.dart';
 import 'package:application_new/domain/place/place_model.dart';
 import 'package:application_new/domain/travel/travel_model.dart';
+import 'package:application_new/shared/interfaces/IconDataProvidable.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -32,10 +33,11 @@ class PlaceMetricModel with _$PlaceMetricModel {
 
 enum PlaceSortType { rating, popularity }
 
-enum PlaceViewType {
+enum ViewType implements IconDataEnum {
   list(Icons.view_list), map(Icons.map);
 
+  @override
   final IconData iconData;
 
-  const PlaceViewType(this.iconData);
+  const ViewType(this.iconData);
 }

--- a/application/lib/feature/travel_plan/page/travel_plan_recommend/page/travel_plan_add_view.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_recommend/page/travel_plan_add_view.dart
@@ -4,7 +4,7 @@ import 'package:application_new/domain/place/place_model.dart';
 import 'package:application_new/domain/travel/travel_model.dart';
 import 'package:application_new/domain/travel_visit/travel_visit_model.dart';
 import 'package:application_new/domain/travel_visit/travel_visit_repository.dart';
-import 'package:application_new/feature/travel_plan/page/travel_plan_manage/page/travel_plan_date_view.dart';
+import 'package:application_new/feature/travel_plan/page/travel_plan_manage/page/travel_plan_date_range_view.dart';
 import 'package:application_new/feature/travel_plan/page/travel_plan_manage/provider/travel_plan_manage_provider.dart';
 import 'package:application_new/feature/travel_plan/page/travel_plan_recommend/component/travel_info_item.dart';
 import 'package:flutter/material.dart';
@@ -63,7 +63,7 @@ class _TravelPlanAddViewState extends ConsumerState<TravelPlanAddView> {
                 child: TravelInfoItem(travel: travel),
               ),
               const SizedBox(height: 24.0),
-              TravelPlanDateView(
+              TravelDateRangeView(
                   travel: travel,
                   selectedDate: selectedDate,
                   onChangeDate: (date) => setState(() => selectedDate = date)),

--- a/application/lib/feature/travel_read/components/place_marker_item.dart
+++ b/application/lib/feature/travel_read/components/place_marker_item.dart
@@ -1,14 +1,18 @@
 import 'package:application_new/domain/place/place_model.dart';
+import 'package:bordered_text/bordered_text.dart';
 import 'package:flutter/material.dart';
 
 class PlaceMarkerItem extends StatelessWidget {
-  final bool _isSelected;
-  final PlaceModel _place;
+  final bool isSelected;
+  final PlaceModel place;
+  final double radius;
 
-  const PlaceMarkerItem(
-      {super.key, required PlaceModel place, required bool isSelected})
-      : _place = place,
-        _isSelected = isSelected;
+  const PlaceMarkerItem({
+    super.key,
+    required this.place,
+    required this.isSelected,
+    this.radius = 16.0,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -16,37 +20,40 @@ class PlaceMarkerItem extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
 
     final labelStyle = TextStyle(
-      fontSize: 10.0,
-      color: colorScheme.onPrimary,
+      fontSize: 13.0,
+      color: colorScheme.primary,
       fontWeight: FontWeight.w600,
     );
 
     final backgroundColor =
-        _isSelected ? colorScheme.primary : colorScheme.secondary;
+        isSelected ? colorScheme.primary : colorScheme.primaryContainer;
     final foregroundColor =
-        _isSelected ? colorScheme.onPrimary : colorScheme.onSecondary;
+        isSelected ? colorScheme.onPrimary : colorScheme.primary;
 
     return Stack(
       clipBehavior: Clip.none,
       alignment: Alignment.center,
       children: [
         Positioned(
-          child: CircleAvatar(
-              radius: 18.0,
-              backgroundColor: backgroundColor,
-              child: Padding(
-                  padding: const EdgeInsets.all(9.0),
-                  child: CircleAvatar(backgroundColor: foregroundColor))),
+          child: Container(
+              width: radius * 2,
+              height: radius * 2,
+              decoration: BoxDecoration(
+                  color: backgroundColor,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: colorScheme.primaryFixedDim)),
+              child: Icon(
+                place.categoryTypes.first.iconData,
+                color: foregroundColor,
+                size: radius / 2,
+              )),
         ),
         Positioned(
-            top: 28.0,
-            child: Container(
-                decoration: BoxDecoration(
-                    color: backgroundColor,
-                    borderRadius: BorderRadius.circular(4.0)),
-                padding:
-                    const EdgeInsets.symmetric(vertical: 2.0, horizontal: 6.0),
-                child: Text(_place.name, style: labelStyle)))
+            top: radius + 4.0,
+            child: BorderedText(
+                strokeColor: Colors.white,
+                strokeWidth: 3.0,
+                child: Text(place.name, style: labelStyle)))
       ],
     );
   }

--- a/application/lib/feature/travel_read/components/place_marker_item.dart
+++ b/application/lib/feature/travel_read/components/place_marker_item.dart
@@ -2,12 +2,12 @@ import 'package:application_new/domain/place/place_model.dart';
 import 'package:bordered_text/bordered_text.dart';
 import 'package:flutter/material.dart';
 
-class PlaceMarkerItem extends StatelessWidget {
+class PlaceWithCategoryMarkerItem extends StatelessWidget {
   final bool isSelected;
   final PlaceModel place;
   final double radius;
 
-  const PlaceMarkerItem({
+  const PlaceWithCategoryMarkerItem({
     super.key,
     required this.place,
     required this.isSelected,
@@ -16,7 +16,6 @@ class PlaceMarkerItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
     final colorScheme = Theme.of(context).colorScheme;
 
     final labelStyle = TextStyle(
@@ -41,7 +40,9 @@ class PlaceMarkerItem extends StatelessWidget {
               decoration: BoxDecoration(
                   color: backgroundColor,
                   shape: BoxShape.circle,
-                  border: Border.all(color: colorScheme.primaryFixedDim)),
+                  border: Border.all(
+                      width: 1.5,
+                      color: colorScheme.primaryFixedDim)),
               child: Icon(
                 place.categoryTypes.first.iconData,
                 color: foregroundColor,

--- a/application/lib/feature/travel_read/components/visits_map_item.dart
+++ b/application/lib/feature/travel_read/components/visits_map_item.dart
@@ -77,7 +77,7 @@ class _VisitsMapItemState extends ConsumerState<VisitsMapItem> {
           width: markerRadius,
           height: markerRadius,
           point: point,
-          child: PlaceMarkerItem(place: place, isSelected: isSelected));
+          child: PlaceWithCategoryMarkerItem(place: place, isSelected: isSelected));
 
       if (isSelected) {
         markers.insert(0, marker);

--- a/application/lib/shared/component/toggle_view_button_item.dart
+++ b/application/lib/shared/component/toggle_view_button_item.dart
@@ -1,0 +1,52 @@
+
+import 'package:application_new/common/util/translation_util.dart';
+import 'package:application_new/shared/interfaces/IconDataProvidable.dart';
+import 'package:flutter/material.dart';
+
+class ToggleViewButtonItem<T extends IconDataEnum> extends StatefulWidget {
+
+  final List<T> viewTypes;
+  final T selectedType;
+  final void Function(int) onToggle;
+
+  const ToggleViewButtonItem({super.key, required this.viewTypes, required this.onToggle, required this.selectedType});
+
+  @override
+  State<ToggleViewButtonItem> createState() => _ToggleViewButtonItemState<T>();
+}
+
+class _ToggleViewButtonItemState<T> extends State<ToggleViewButtonItem> {
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData(:textTheme, :colorScheme) = Theme.of(context);
+
+    return Container(
+        decoration: BoxDecoration(
+          color: colorScheme.surface,
+          borderRadius: BorderRadius.circular(12.0),
+        ),
+        child: ToggleButtons(
+            fillColor: colorScheme.primaryContainer,
+            borderColor: colorScheme.surfaceContainerHighest,
+            selectedBorderColor: colorScheme.primaryFixedDim,
+            borderRadius: BorderRadius.circular(12.0),
+            textStyle: const TextStyle(fontWeight: FontWeight.w600),
+            onPressed: widget.onToggle,
+            isSelected: widget.viewTypes
+                .map((viewType) => viewType == widget.selectedType)
+                .toList(),
+            children: [
+              for (final viewType in widget.viewTypes)
+                Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(viewType.iconData, size: 18.0),
+                          const SizedBox(width: 8.0),
+                          Text(TranslationUtil.enumValue(viewType)),
+                        ])),
+            ]));
+  }
+}

--- a/application/lib/shared/component/tonal_filled_icon_button.dart
+++ b/application/lib/shared/component/tonal_filled_icon_button.dart
@@ -1,26 +1,30 @@
 import 'package:flutter/material.dart';
 
-final class OutlinedIconButton extends StatelessWidget {
+final class TonalFilledIconButton extends StatelessWidget {
   final Icon icon;
   final VoidCallback? onPressed;
   final double? iconSize;
   final Color? foregroundColor;
 
-  const OutlinedIconButton(
-      {super.key, required this.icon, this.onPressed, this.iconSize, this.foregroundColor});
+  const TonalFilledIconButton(
+      {super.key,
+      required this.icon,
+      this.onPressed,
+      this.iconSize,
+      this.foregroundColor});
 
   @override
   Widget build(BuildContext context) {
     final ThemeData(:textTheme, :colorScheme) = Theme.of(context);
 
-    return IconButton(
+    return IconButton.filledTonal(
       style: IconButton.styleFrom(
           iconSize: iconSize ?? 18.0,
-          foregroundColor: foregroundColor ?? colorScheme.primary,
           padding: EdgeInsets.zero,
           shape:
-              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12.0)),
-          side: BorderSide(color: colorScheme.surfaceDim)),
+              RoundedRectangleBorder(
+                  side: BorderSide(color: colorScheme.primaryFixedDim),
+                  borderRadius: BorderRadius.circular(12.0))),
       onPressed: onPressed ?? () {},
       icon: icon,
     );

--- a/application/lib/shared/interfaces/IconDataProvidable.dart
+++ b/application/lib/shared/interfaces/IconDataProvidable.dart
@@ -1,0 +1,8 @@
+
+import 'package:flutter/material.dart';
+
+abstract interface class IconDataEnum implements Enum {
+
+  IconData get iconData;
+
+}

--- a/application/pubspec.lock
+++ b/application/pubspec.lock
@@ -54,6 +54,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  bordered_text:
+    dependency: "direct main"
+    description:
+      name: bordered_text
+      sha256: e52c549c9d01fdf6359eee7220900eb5a5853b08aa862c8c604442918ca6b4c4
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   build:
     dependency: transitive
     description:
@@ -294,14 +302,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
-  drag_and_drop_lists:
-    dependency: "direct main"
-    description:
-      name: drag_and_drop_lists
-      sha256: "83fab4a9d4d99d9c683858ac5e1975028d87aa796bf68bfd654b19154004b6bb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.1"
   easy_localization:
     dependency: "direct main"
     description:

--- a/application/pubspec.yaml
+++ b/application/pubspec.yaml
@@ -58,9 +58,9 @@ dependencies:
   infinite_scroll_pagination: ^4.0.0
   flutter_staggered_grid_view: ^0.7.0
   extended_wrap: ^0.1.5
-  drag_and_drop_lists: ^0.4.1
   vector_map_tiles: ^8.0.0
   uuid: ^4.5.1
+  bordered_text: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> Ex. close #이슈 번호, #이슈 번호
close #20 

## 📝 작업 내용
> 작업한 내용을 간략히 설명해 주세요.

### 여행 계획 지도 뷰 UI 설계
<img src="https://github.com/user-attachments/assets/43273b1f-ee1a-4907-a4a8-08d12f5daeae" width="240px" />

계획에 등록한 관광지의 위치 및 각 경로를 확인하기 위해, 계획 화면에 지도 뷰를 배치하려 했습니다. 하지만 이미 계획 페이지에서 순서 및 날짜 수정 기능이 있어 **도저히 공간이 부족**했습니다.

여기서 두 가지 해결책을 생각했습니다.
1. 토글 버튼으로 계획 리스트, 지도 뷰를 전환하며 표시한다.
2. 지도 뷰의 크기를 제스쳐 등으로 확대/축소한다.

일단 (1) 안을 간단히 구현해 봤는데, 계획 목록과 지도 화면을 전환하면서 봐야 하는게 상상 이상으로 번거로웠습니다. 그래서 **"계획 목록을 확인하며 지도에서 관광지 위치, 경로등을 본다"라는 목적에 맞지 않다고 생각했습니다.** 

### 확장/축소가 가능한 지도 뷰 구현
![Simulator Screen Recording - iPhone 15 Pro Max - 2024-11-21 at 14 13 07](https://github.com/user-attachments/assets/762d6b40-acc5-4a7d-986d-bfd6d5fdc480)

그래서 (2) 안을 채택해 구현했습니다. 드래그 핸들을 위/아래로 Swipe 해 지도를 3단계로 확장/축소 할 수 있습니다.
- 완전히 확대된 경우 리스트 전체를, 축소된 경우 날짜만 표시되도록 했습니다.
- `Curves.ease` 효과를 사용해 시트 확장/축소 애니메이션을 자연스럽게 설정했습니다.

## ✅ 작업 결과
> 작업 내용 Notion 링크, 혹은 이미지를 첨부해 주세요.

## 💬 추가 사항 (선택)
> 추가로 기재할 사항이 있으면 기재해 주세요.

### 반환할 위젯의 상위 위젯을 받는 방법

<img src="https://github.com/user-attachments/assets/63baa3b6-e9d2-47db-828c-71e5d2b898f2" width="240px" />
<img src="https://github.com/user-attachments/assets/31372fc0-f68a-4871-b51b-e4105970ed37" width="240px" />

여행 날짜의 범위를 표시하는 `TravelDateRangeVIew` 위젯은 여러 UI에서 쓰입니다. 그런데 왼쪽처럼 `DragTarget`이 필요한 경우, 오른쪽처럼 필요없는 경우로 나뉩니다.

```dart

  final Widget Function(TravelDateItem item, int index)? builder;

  @override
  Widget build(BuildContext context, WidgetRef ref) {

    final ThemeData(:textTheme, :colorScheme) = Theme.of(context);

    final daysOfTravel =
        DateTimeRange(start: travel.startedOn, end: travel.endedOn)
            .duration
            .inDays;

    final builder = this.builder ?? (TravelDateItem item, int index) => item;

    return Container ... (child: builder(item, index));
  }
```
여기서 두 위젯을 만들어 분리해도 되지만, 향후 유지 보수를 위해 **`builder` 패턴으로 상위 위젯을 선택적으로 받을 수 있도록 개선**했습니다.
- `Caller`에게 반환할 위젯 및 인덱스를 파라미터로 받고, 위젯을 반환하는 `builder` 함수를 파라미터로 받습니다. 
- 만약 지정하지 않으면 `Item`을 그대로 반환하는 함수를 사용합니다.

이처럼, **함수형 프로그래밍의 "일급 객체" 개념을 적용**해 유연한 위젯 트리 구조를 만들 수 있었습니다.
