### PR TITLE
Feature(#7): 여행 참여자 UI & 추방 기능 연결

### DIFF
--- a/application/assets/translations/en.yaml
+++ b/application/assets/translations/en.yaml
@@ -48,6 +48,10 @@ unknown_error_occurred: An unknown error has occurred. Please try again later.
 you_have_joined_in_travel_name: You've joined in {}
 
 retry: Retry
+leave: Leave
+kick: Kick
+
+travel_participants: Travel participants
 
 widget:
   VisitListItem:

--- a/application/assets/translations/ko.yaml
+++ b/application/assets/translations/ko.yaml
@@ -50,6 +50,10 @@ unknown_error_occurred: 알 수 없는 오류가 발생했습니다. 잠시 후 
 you_have_joined_in_travel_name: '{}에 참여했습니다.'
 
 retry: 다시 시도하기
+leave: 떠나기
+kick: 추방하기
+
+travel_participants: 여행 일행
 
 widget:
   VisitListItem:

--- a/application/assets/translations/ko.yaml
+++ b/application/assets/translations/ko.yaml
@@ -21,7 +21,7 @@ sort_by: 정렬 조건
 
 invite_new_participant: 새 일행 초대하기
 share_link_to_invite: • 초대 링크를 공유해 일행을 초대할 수 있어요.
-share_link_expires_after_30_min: • 초대 링크는 30분 후에 만료되요.
+link_expires_after_30_min: • 초대 링크는 30분 후에 만료되요.
 can_plan_with_participants: • 일행과 함께 여행 계획을 짤 수 있어요.
 share_invitation_link: 초대 링크 공유하기
 

--- a/application/lib/common/router/router_provider.dart
+++ b/application/lib/common/router/router_provider.dart
@@ -5,11 +5,13 @@ import 'package:application_new/feature/error/error_page.dart';
 import 'package:application_new/feature/home/home_page.dart';
 import 'package:application_new/feature/travel_create/page/travel_create_page.dart';
 import 'package:application_new/feature/travel_invitation/page/travel_invitation_page.dart';
+import 'package:application_new/feature/travel_plan/page/travel_plan_participant/page/travel_plan_participant_page.dart';
 import 'package:application_new/feature/travel_plan/page/travel_plan_recommend/page/city_travels/page/city_travels_page.dart';
 import 'package:application_new/feature/travel_read/page/travel_read_page.dart';
 import 'package:application_new/feature/travel_list/page/travel_list_page.dart';
 import 'package:application_new/feature/travel_plan/page/travel_plan_page.dart';
 import 'package:go_router/go_router.dart';
+import 'package:path/path.dart';
 
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -105,6 +107,13 @@ GoRouter router(RouterRef ref) {
 
             return TravelInvitationPage(
                 travelId: int.parse(travelId), invitationId: invitationId);
+          }),
+      GoRoute(
+          path: '/travels/:travelId/participants',
+          builder: (context, state) {
+            final {'travelId': travelId} = state.pathParameters;
+
+            return TravelPlanParticipantPage(travelId: int.parse(travelId));
           })
     ],
   );

--- a/application/lib/common/router/router_provider.g.dart
+++ b/application/lib/common/router/router_provider.g.dart
@@ -6,7 +6,7 @@ part of 'router_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$routerHash() => r'ee38cd2b57001c7a78671df9887c3bfc9ab05d3f';
+String _$routerHash() => r'8eab139f3439798446021dec21732e52ac623a03';
 
 /// See also [router].
 @ProviderFor(router)

--- a/application/lib/common/session/session_model.dart
+++ b/application/lib/common/session/session_model.dart
@@ -1,3 +1,4 @@
+import 'package:application_new/domain/member/member_model.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'session_model.freezed.dart';
@@ -7,6 +8,7 @@ class SessionModel with _$SessionModel {
 
   const factory SessionModel({
     @Default(false) bool isAuthenticated,
+    MemberModel? member,
     String? errorMessage,
   }) = _SessionModel;
 

--- a/application/lib/common/session/session_model.freezed.dart
+++ b/application/lib/common/session/session_model.freezed.dart
@@ -17,6 +17,7 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$SessionModel {
   bool get isAuthenticated => throw _privateConstructorUsedError;
+  MemberModel? get member => throw _privateConstructorUsedError;
   String? get errorMessage => throw _privateConstructorUsedError;
 
   /// Create a copy of SessionModel
@@ -32,7 +33,9 @@ abstract class $SessionModelCopyWith<$Res> {
           SessionModel value, $Res Function(SessionModel) then) =
       _$SessionModelCopyWithImpl<$Res, SessionModel>;
   @useResult
-  $Res call({bool isAuthenticated, String? errorMessage});
+  $Res call({bool isAuthenticated, MemberModel? member, String? errorMessage});
+
+  $MemberModelCopyWith<$Res>? get member;
 }
 
 /// @nodoc
@@ -51,6 +54,7 @@ class _$SessionModelCopyWithImpl<$Res, $Val extends SessionModel>
   @override
   $Res call({
     Object? isAuthenticated = null,
+    Object? member = freezed,
     Object? errorMessage = freezed,
   }) {
     return _then(_value.copyWith(
@@ -58,11 +62,29 @@ class _$SessionModelCopyWithImpl<$Res, $Val extends SessionModel>
           ? _value.isAuthenticated
           : isAuthenticated // ignore: cast_nullable_to_non_nullable
               as bool,
+      member: freezed == member
+          ? _value.member
+          : member // ignore: cast_nullable_to_non_nullable
+              as MemberModel?,
       errorMessage: freezed == errorMessage
           ? _value.errorMessage
           : errorMessage // ignore: cast_nullable_to_non_nullable
               as String?,
     ) as $Val);
+  }
+
+  /// Create a copy of SessionModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $MemberModelCopyWith<$Res>? get member {
+    if (_value.member == null) {
+      return null;
+    }
+
+    return $MemberModelCopyWith<$Res>(_value.member!, (value) {
+      return _then(_value.copyWith(member: value) as $Val);
+    });
   }
 }
 
@@ -74,7 +96,10 @@ abstract class _$$SessionModelImplCopyWith<$Res>
       __$$SessionModelImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({bool isAuthenticated, String? errorMessage});
+  $Res call({bool isAuthenticated, MemberModel? member, String? errorMessage});
+
+  @override
+  $MemberModelCopyWith<$Res>? get member;
 }
 
 /// @nodoc
@@ -91,6 +116,7 @@ class __$$SessionModelImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? isAuthenticated = null,
+    Object? member = freezed,
     Object? errorMessage = freezed,
   }) {
     return _then(_$SessionModelImpl(
@@ -98,6 +124,10 @@ class __$$SessionModelImplCopyWithImpl<$Res>
           ? _value.isAuthenticated
           : isAuthenticated // ignore: cast_nullable_to_non_nullable
               as bool,
+      member: freezed == member
+          ? _value.member
+          : member // ignore: cast_nullable_to_non_nullable
+              as MemberModel?,
       errorMessage: freezed == errorMessage
           ? _value.errorMessage
           : errorMessage // ignore: cast_nullable_to_non_nullable
@@ -109,17 +139,20 @@ class __$$SessionModelImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$SessionModelImpl implements _SessionModel {
-  const _$SessionModelImpl({this.isAuthenticated = false, this.errorMessage});
+  const _$SessionModelImpl(
+      {this.isAuthenticated = false, this.member, this.errorMessage});
 
   @override
   @JsonKey()
   final bool isAuthenticated;
   @override
+  final MemberModel? member;
+  @override
   final String? errorMessage;
 
   @override
   String toString() {
-    return 'SessionModel(isAuthenticated: $isAuthenticated, errorMessage: $errorMessage)';
+    return 'SessionModel(isAuthenticated: $isAuthenticated, member: $member, errorMessage: $errorMessage)';
   }
 
   @override
@@ -129,12 +162,14 @@ class _$SessionModelImpl implements _SessionModel {
             other is _$SessionModelImpl &&
             (identical(other.isAuthenticated, isAuthenticated) ||
                 other.isAuthenticated == isAuthenticated) &&
+            (identical(other.member, member) || other.member == member) &&
             (identical(other.errorMessage, errorMessage) ||
                 other.errorMessage == errorMessage));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, isAuthenticated, errorMessage);
+  int get hashCode =>
+      Object.hash(runtimeType, isAuthenticated, member, errorMessage);
 
   /// Create a copy of SessionModel
   /// with the given fields replaced by the non-null parameter values.
@@ -148,10 +183,13 @@ class _$SessionModelImpl implements _SessionModel {
 abstract class _SessionModel implements SessionModel {
   const factory _SessionModel(
       {final bool isAuthenticated,
+      final MemberModel? member,
       final String? errorMessage}) = _$SessionModelImpl;
 
   @override
   bool get isAuthenticated;
+  @override
+  MemberModel? get member;
   @override
   String? get errorMessage;
 

--- a/application/lib/common/session/session_provider.dart
+++ b/application/lib/common/session/session_provider.dart
@@ -1,4 +1,5 @@
 import 'package:application_new/common/session/session_model.dart';
+import 'package:application_new/domain/member/member_model.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'session_provider.g.dart';
@@ -10,15 +11,17 @@ class Session extends _$Session {
     return const SessionModel();
   }
 
-  void update({required bool isAuthenticated}) {
+  void update({required bool isAuthenticated, MemberModel? member}) {
     if (state.isAuthenticated == isAuthenticated) {
       return;
     }
 
     state = state.copyWith(
       isAuthenticated: isAuthenticated,
+      member: isAuthenticated ? member : null,
     );
   }
+
 
   void omitError(String message) {
     state = state.copyWith(errorMessage: message);

--- a/application/lib/common/session/session_provider.g.dart
+++ b/application/lib/common/session/session_provider.g.dart
@@ -6,7 +6,7 @@ part of 'session_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$sessionHash() => r'9abe1349b13991bf3c719f6658103676ec8b5732';
+String _$sessionHash() => r'af561a44451daf7b2ed152371c598845213b0c70';
 
 /// See also [Session].
 @ProviderFor(Session)

--- a/application/lib/common/translation/easy_local_tranlation_service.dart
+++ b/application/lib/common/translation/easy_local_tranlation_service.dart
@@ -10,9 +10,10 @@ final class EasyLocalTranslationService implements TranslationService {
   }
 
   @override
-  String fromEnum<T extends Enum>(T key) {
-    // TODO: implement fromEnum
-    throw UnimplementedError();
+  String fromEnum<T extends Enum>(T? key) {
+    if (key == null) return 'null'.tr();
+
+    return 'enum.${key.runtimeType}.values.${key.name}'.tr();
   }
 
 }

--- a/application/lib/domain/member/member_model.dart
+++ b/application/lib/domain/member/member_model.dart
@@ -7,7 +7,7 @@ part 'member_model.g.dart';
 @freezed
 class MemberModel with _$MemberModel {
   const factory MemberModel({
-    required int id,
+    required String id,
     AgeGroup? ageGroup,
     Gender? gender,
   }) = _MemberModel;

--- a/application/lib/domain/member/member_model.dart
+++ b/application/lib/domain/member/member_model.dart
@@ -1,0 +1,17 @@
+import 'package:application_new/shared/model/member_model.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'member_model.freezed.dart';
+part 'member_model.g.dart';
+
+@freezed
+class MemberModel with _$MemberModel {
+  const factory MemberModel({
+    required int id,
+    AgeGroup? ageGroup,
+    Gender? gender,
+  }) = _MemberModel;
+
+  factory MemberModel.fromJson(Map<String, dynamic> json) =>
+      _$MemberModelFromJson(json);
+}

--- a/application/lib/domain/member/member_model.freezed.dart
+++ b/application/lib/domain/member/member_model.freezed.dart
@@ -1,0 +1,200 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'member_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+MemberModel _$MemberModelFromJson(Map<String, dynamic> json) {
+  return _MemberModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$MemberModel {
+  int get id => throw _privateConstructorUsedError;
+  AgeGroup? get ageGroup => throw _privateConstructorUsedError;
+  Gender? get gender => throw _privateConstructorUsedError;
+
+  /// Serializes this MemberModel to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of MemberModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $MemberModelCopyWith<MemberModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MemberModelCopyWith<$Res> {
+  factory $MemberModelCopyWith(
+          MemberModel value, $Res Function(MemberModel) then) =
+      _$MemberModelCopyWithImpl<$Res, MemberModel>;
+  @useResult
+  $Res call({int id, AgeGroup? ageGroup, Gender? gender});
+}
+
+/// @nodoc
+class _$MemberModelCopyWithImpl<$Res, $Val extends MemberModel>
+    implements $MemberModelCopyWith<$Res> {
+  _$MemberModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of MemberModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? ageGroup = freezed,
+    Object? gender = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      ageGroup: freezed == ageGroup
+          ? _value.ageGroup
+          : ageGroup // ignore: cast_nullable_to_non_nullable
+              as AgeGroup?,
+      gender: freezed == gender
+          ? _value.gender
+          : gender // ignore: cast_nullable_to_non_nullable
+              as Gender?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$MemberModelImplCopyWith<$Res>
+    implements $MemberModelCopyWith<$Res> {
+  factory _$$MemberModelImplCopyWith(
+          _$MemberModelImpl value, $Res Function(_$MemberModelImpl) then) =
+      __$$MemberModelImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int id, AgeGroup? ageGroup, Gender? gender});
+}
+
+/// @nodoc
+class __$$MemberModelImplCopyWithImpl<$Res>
+    extends _$MemberModelCopyWithImpl<$Res, _$MemberModelImpl>
+    implements _$$MemberModelImplCopyWith<$Res> {
+  __$$MemberModelImplCopyWithImpl(
+      _$MemberModelImpl _value, $Res Function(_$MemberModelImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of MemberModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? ageGroup = freezed,
+    Object? gender = freezed,
+  }) {
+    return _then(_$MemberModelImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      ageGroup: freezed == ageGroup
+          ? _value.ageGroup
+          : ageGroup // ignore: cast_nullable_to_non_nullable
+              as AgeGroup?,
+      gender: freezed == gender
+          ? _value.gender
+          : gender // ignore: cast_nullable_to_non_nullable
+              as Gender?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$MemberModelImpl implements _MemberModel {
+  const _$MemberModelImpl({required this.id, this.ageGroup, this.gender});
+
+  factory _$MemberModelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MemberModelImplFromJson(json);
+
+  @override
+  final int id;
+  @override
+  final AgeGroup? ageGroup;
+  @override
+  final Gender? gender;
+
+  @override
+  String toString() {
+    return 'MemberModel(id: $id, ageGroup: $ageGroup, gender: $gender)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MemberModelImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.ageGroup, ageGroup) ||
+                other.ageGroup == ageGroup) &&
+            (identical(other.gender, gender) || other.gender == gender));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, ageGroup, gender);
+
+  /// Create a copy of MemberModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MemberModelImplCopyWith<_$MemberModelImpl> get copyWith =>
+      __$$MemberModelImplCopyWithImpl<_$MemberModelImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$MemberModelImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _MemberModel implements MemberModel {
+  const factory _MemberModel(
+      {required final int id,
+      final AgeGroup? ageGroup,
+      final Gender? gender}) = _$MemberModelImpl;
+
+  factory _MemberModel.fromJson(Map<String, dynamic> json) =
+      _$MemberModelImpl.fromJson;
+
+  @override
+  int get id;
+  @override
+  AgeGroup? get ageGroup;
+  @override
+  Gender? get gender;
+
+  /// Create a copy of MemberModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$MemberModelImplCopyWith<_$MemberModelImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/application/lib/domain/member/member_model.freezed.dart
+++ b/application/lib/domain/member/member_model.freezed.dart
@@ -20,7 +20,7 @@ MemberModel _$MemberModelFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$MemberModel {
-  int get id => throw _privateConstructorUsedError;
+  String get id => throw _privateConstructorUsedError;
   AgeGroup? get ageGroup => throw _privateConstructorUsedError;
   Gender? get gender => throw _privateConstructorUsedError;
 
@@ -40,7 +40,7 @@ abstract class $MemberModelCopyWith<$Res> {
           MemberModel value, $Res Function(MemberModel) then) =
       _$MemberModelCopyWithImpl<$Res, MemberModel>;
   @useResult
-  $Res call({int id, AgeGroup? ageGroup, Gender? gender});
+  $Res call({String id, AgeGroup? ageGroup, Gender? gender});
 }
 
 /// @nodoc
@@ -66,7 +66,7 @@ class _$MemberModelCopyWithImpl<$Res, $Val extends MemberModel>
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as String,
       ageGroup: freezed == ageGroup
           ? _value.ageGroup
           : ageGroup // ignore: cast_nullable_to_non_nullable
@@ -87,7 +87,7 @@ abstract class _$$MemberModelImplCopyWith<$Res>
       __$$MemberModelImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({int id, AgeGroup? ageGroup, Gender? gender});
+  $Res call({String id, AgeGroup? ageGroup, Gender? gender});
 }
 
 /// @nodoc
@@ -111,7 +111,7 @@ class __$$MemberModelImplCopyWithImpl<$Res>
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as String,
       ageGroup: freezed == ageGroup
           ? _value.ageGroup
           : ageGroup // ignore: cast_nullable_to_non_nullable
@@ -133,7 +133,7 @@ class _$MemberModelImpl implements _MemberModel {
       _$$MemberModelImplFromJson(json);
 
   @override
-  final int id;
+  final String id;
   @override
   final AgeGroup? ageGroup;
   @override
@@ -177,7 +177,7 @@ class _$MemberModelImpl implements _MemberModel {
 
 abstract class _MemberModel implements MemberModel {
   const factory _MemberModel(
-      {required final int id,
+      {required final String id,
       final AgeGroup? ageGroup,
       final Gender? gender}) = _$MemberModelImpl;
 
@@ -185,7 +185,7 @@ abstract class _MemberModel implements MemberModel {
       _$MemberModelImpl.fromJson;
 
   @override
-  int get id;
+  String get id;
   @override
   AgeGroup? get ageGroup;
   @override

--- a/application/lib/domain/member/member_model.g.dart
+++ b/application/lib/domain/member/member_model.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'member_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$MemberModelImpl _$$MemberModelImplFromJson(Map<String, dynamic> json) =>
+    _$MemberModelImpl(
+      id: (json['id'] as num).toInt(),
+      ageGroup: $enumDecodeNullable(_$AgeGroupEnumMap, json['ageGroup']),
+      gender: $enumDecodeNullable(_$GenderEnumMap, json['gender']),
+    );
+
+Map<String, dynamic> _$$MemberModelImplToJson(_$MemberModelImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'ageGroup': _$AgeGroupEnumMap[instance.ageGroup],
+      'gender': _$GenderEnumMap[instance.gender],
+    };
+
+const _$AgeGroupEnumMap = {
+  AgeGroup.underNine: 'underNine',
+  AgeGroup.teens: 'teens',
+  AgeGroup.twenties: 'twenties',
+  AgeGroup.thirties: 'thirties',
+  AgeGroup.forties: 'forties',
+  AgeGroup.fifties: 'fifties',
+  AgeGroup.sixties: 'sixties',
+  AgeGroup.seventiesPlus: 'seventiesPlus',
+  AgeGroup.none: 'none',
+};
+
+const _$GenderEnumMap = {
+  Gender.male: 'male',
+  Gender.female: 'female',
+};

--- a/application/lib/domain/member/member_model.g.dart
+++ b/application/lib/domain/member/member_model.g.dart
@@ -8,7 +8,7 @@ part of 'member_model.dart';
 
 _$MemberModelImpl _$$MemberModelImplFromJson(Map<String, dynamic> json) =>
     _$MemberModelImpl(
-      id: (json['id'] as num).toInt(),
+      id: json['id'] as String,
       ageGroup: $enumDecodeNullable(_$AgeGroupEnumMap, json['ageGroup']),
       gender: $enumDecodeNullable(_$GenderEnumMap, json['gender']),
     );
@@ -29,7 +29,6 @@ const _$AgeGroupEnumMap = {
   AgeGroup.fifties: 'fifties',
   AgeGroup.sixties: 'sixties',
   AgeGroup.seventiesPlus: 'seventiesPlus',
-  AgeGroup.none: 'none',
 };
 
 const _$GenderEnumMap = {

--- a/application/lib/domain/member/member_provider.dart
+++ b/application/lib/domain/member/member_provider.dart
@@ -1,0 +1,14 @@
+import 'package:application_new/common/http/http_service_provider.dart';
+import 'package:application_new/domain/member/member_model.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'member_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+Future<MemberModel> member(MemberRef ref, String id) async {
+  final response = await ref
+      .watch(httpServiceProvider)
+      .request('GET', '/api/v2/members/$id');
+
+  return MemberModel.fromJson(response['member']);
+}

--- a/application/lib/domain/member/member_provider.dart
+++ b/application/lib/domain/member/member_provider.dart
@@ -8,7 +8,7 @@ part 'member_provider.g.dart';
 Future<MemberModel> member(MemberRef ref, String id) async {
   final response = await ref
       .watch(httpServiceProvider)
-      .request('GET', '/api/v2/members/$id');
+      .request('GET', '/api/v2/members/$id'); 
 
   return MemberModel.fromJson(response['member']);
 }

--- a/application/lib/domain/member/member_provider.g.dart
+++ b/application/lib/domain/member/member_provider.g.dart
@@ -1,0 +1,157 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'member_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$memberHash() => r'8874d6650b1f9e6ceda0744c43facaedd74e63ae';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+/// See also [member].
+@ProviderFor(member)
+const memberProvider = MemberFamily();
+
+/// See also [member].
+class MemberFamily extends Family<AsyncValue<MemberModel>> {
+  /// See also [member].
+  const MemberFamily();
+
+  /// See also [member].
+  MemberProvider call(
+    String id,
+  ) {
+    return MemberProvider(
+      id,
+    );
+  }
+
+  @override
+  MemberProvider getProviderOverride(
+    covariant MemberProvider provider,
+  ) {
+    return call(
+      provider.id,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'memberProvider';
+}
+
+/// See also [member].
+class MemberProvider extends FutureProvider<MemberModel> {
+  /// See also [member].
+  MemberProvider(
+    String id,
+  ) : this._internal(
+          (ref) => member(
+            ref as MemberRef,
+            id,
+          ),
+          from: memberProvider,
+          name: r'memberProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$memberHash,
+          dependencies: MemberFamily._dependencies,
+          allTransitiveDependencies: MemberFamily._allTransitiveDependencies,
+          id: id,
+        );
+
+  MemberProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.id,
+  }) : super.internal();
+
+  final String id;
+
+  @override
+  Override overrideWith(
+    FutureOr<MemberModel> Function(MemberRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: MemberProvider._internal(
+        (ref) => create(ref as MemberRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        id: id,
+      ),
+    );
+  }
+
+  @override
+  FutureProviderElement<MemberModel> createElement() {
+    return _MemberProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is MemberProvider && other.id == id;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, id.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin MemberRef on FutureProviderRef<MemberModel> {
+  /// The parameter `id` of this provider.
+  String get id;
+}
+
+class _MemberProviderElement extends FutureProviderElement<MemberModel>
+    with MemberRef {
+  _MemberProviderElement(super.provider);
+
+  @override
+  String get id => (origin as MemberProvider).id;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/application/lib/domain/travel/travel_model.dart
+++ b/application/lib/domain/travel/travel_model.dart
@@ -19,6 +19,7 @@ class TravelModel with _$TravelModel {
     required DateTime endedOn,
     AgeGroup? ageGroup,
     Gender? gender,
+    String? memberId,
     required List<TravelCompanionModel> companions,
     required List<TravelMotivationType> motivationTypes,
     required List<CityModel> cities,
@@ -84,7 +85,7 @@ class TravelParticipantModel with _$TravelParticipantModel {
     required int id,
     required int travelId,
     required String inviteeId,
-    required String invitorId,
+    required String inviterId,
   }) = _TravelParticipantModel;
 
   factory TravelParticipantModel.fromJson(Map<String, dynamic> json) =>

--- a/application/lib/domain/travel/travel_model.dart
+++ b/application/lib/domain/travel/travel_model.dart
@@ -37,7 +37,6 @@ class TravelModel with _$TravelModel {
 
 @freezed
 class TravelFormModel with _$TravelFormModel {
-
   const TravelFormModel._();
 
   const factory TravelFormModel({
@@ -53,18 +52,17 @@ class TravelFormModel with _$TravelFormModel {
       endedOn: state.endedOn,
       motivationTypes: state.motivationTypes,
       companionTypes: state.companionTypes,
-      cities: state.cities
-  );
+      cities: state.cities);
 
   Map<String, dynamic> toMap() => {
-    'date': {
-      'startedOn': startedOn?.toIso8601String(),
-      'endedOn': endedOn?.toIso8601String(),
-    },
-    'companionTypes': companionTypes.map((e) => e.name).toList(),
-    'motivationTypes': motivationTypes.map((e) => e.name).toList(),
-    'cities': cities,
-  };
+        'date': {
+          'startedOn': startedOn?.toIso8601String(),
+          'endedOn': endedOn?.toIso8601String(),
+        },
+        'companionTypes': companionTypes.map((e) => e.name).toList(),
+        'motivationTypes': motivationTypes.map((e) => e.name).toList(),
+        'cities': cities,
+      };
 }
 
 @freezed
@@ -78,6 +76,25 @@ class TravelCompanionModel with _$TravelCompanionModel {
 
   factory TravelCompanionModel.fromJson(Map<String, dynamic> json) =>
       _$TravelCompanionModelFromJson(json);
+}
+
+@freezed
+class TravelParticipantModel with _$TravelParticipantModel {
+  const factory TravelParticipantModel({
+    required int id,
+    required int travelId,
+    required String inviteeId,
+    required String invitorId,
+  }) = _TravelParticipantModel;
+
+  factory TravelParticipantModel.fromJson(Map<String, dynamic> json) =>
+      _$TravelParticipantModelFromJson(json);
+
+  static List<TravelParticipantModel> listFromJson(Map<String, dynamic> json) {
+    return List.of(json['participants'])
+        .map((e) => TravelParticipantModel.fromJson(e))
+        .toList();
+  }
 }
 
 enum TravelMotivationType {

--- a/application/lib/domain/travel/travel_model.freezed.dart
+++ b/application/lib/domain/travel/travel_model.freezed.dart
@@ -776,3 +776,218 @@ abstract class _TravelCompanion implements TravelCompanionModel {
   _$$TravelCompanionImplCopyWith<_$TravelCompanionImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
+
+TravelParticipantModel _$TravelParticipantModelFromJson(
+    Map<String, dynamic> json) {
+  return _TravelParticipantModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$TravelParticipantModel {
+  int get id => throw _privateConstructorUsedError;
+  int get travelId => throw _privateConstructorUsedError;
+  String get inviteeId => throw _privateConstructorUsedError;
+  String get invitorId => throw _privateConstructorUsedError;
+
+  /// Serializes this TravelParticipantModel to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of TravelParticipantModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $TravelParticipantModelCopyWith<TravelParticipantModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TravelParticipantModelCopyWith<$Res> {
+  factory $TravelParticipantModelCopyWith(TravelParticipantModel value,
+          $Res Function(TravelParticipantModel) then) =
+      _$TravelParticipantModelCopyWithImpl<$Res, TravelParticipantModel>;
+  @useResult
+  $Res call({int id, int travelId, String inviteeId, String invitorId});
+}
+
+/// @nodoc
+class _$TravelParticipantModelCopyWithImpl<$Res,
+        $Val extends TravelParticipantModel>
+    implements $TravelParticipantModelCopyWith<$Res> {
+  _$TravelParticipantModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of TravelParticipantModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? travelId = null,
+    Object? inviteeId = null,
+    Object? invitorId = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      travelId: null == travelId
+          ? _value.travelId
+          : travelId // ignore: cast_nullable_to_non_nullable
+              as int,
+      inviteeId: null == inviteeId
+          ? _value.inviteeId
+          : inviteeId // ignore: cast_nullable_to_non_nullable
+              as String,
+      invitorId: null == invitorId
+          ? _value.invitorId
+          : invitorId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$TravelParticipantModelImplCopyWith<$Res>
+    implements $TravelParticipantModelCopyWith<$Res> {
+  factory _$$TravelParticipantModelImplCopyWith(
+          _$TravelParticipantModelImpl value,
+          $Res Function(_$TravelParticipantModelImpl) then) =
+      __$$TravelParticipantModelImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int id, int travelId, String inviteeId, String invitorId});
+}
+
+/// @nodoc
+class __$$TravelParticipantModelImplCopyWithImpl<$Res>
+    extends _$TravelParticipantModelCopyWithImpl<$Res,
+        _$TravelParticipantModelImpl>
+    implements _$$TravelParticipantModelImplCopyWith<$Res> {
+  __$$TravelParticipantModelImplCopyWithImpl(
+      _$TravelParticipantModelImpl _value,
+      $Res Function(_$TravelParticipantModelImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of TravelParticipantModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? travelId = null,
+    Object? inviteeId = null,
+    Object? invitorId = null,
+  }) {
+    return _then(_$TravelParticipantModelImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      travelId: null == travelId
+          ? _value.travelId
+          : travelId // ignore: cast_nullable_to_non_nullable
+              as int,
+      inviteeId: null == inviteeId
+          ? _value.inviteeId
+          : inviteeId // ignore: cast_nullable_to_non_nullable
+              as String,
+      invitorId: null == invitorId
+          ? _value.invitorId
+          : invitorId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$TravelParticipantModelImpl implements _TravelParticipantModel {
+  const _$TravelParticipantModelImpl(
+      {required this.id,
+      required this.travelId,
+      required this.inviteeId,
+      required this.invitorId});
+
+  factory _$TravelParticipantModelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TravelParticipantModelImplFromJson(json);
+
+  @override
+  final int id;
+  @override
+  final int travelId;
+  @override
+  final String inviteeId;
+  @override
+  final String invitorId;
+
+  @override
+  String toString() {
+    return 'TravelParticipantModel(id: $id, travelId: $travelId, inviteeId: $inviteeId, invitorId: $invitorId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TravelParticipantModelImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.travelId, travelId) ||
+                other.travelId == travelId) &&
+            (identical(other.inviteeId, inviteeId) ||
+                other.inviteeId == inviteeId) &&
+            (identical(other.invitorId, invitorId) ||
+                other.invitorId == invitorId));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, id, travelId, inviteeId, invitorId);
+
+  /// Create a copy of TravelParticipantModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TravelParticipantModelImplCopyWith<_$TravelParticipantModelImpl>
+      get copyWith => __$$TravelParticipantModelImplCopyWithImpl<
+          _$TravelParticipantModelImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$TravelParticipantModelImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _TravelParticipantModel implements TravelParticipantModel {
+  const factory _TravelParticipantModel(
+      {required final int id,
+      required final int travelId,
+      required final String inviteeId,
+      required final String invitorId}) = _$TravelParticipantModelImpl;
+
+  factory _TravelParticipantModel.fromJson(Map<String, dynamic> json) =
+      _$TravelParticipantModelImpl.fromJson;
+
+  @override
+  int get id;
+  @override
+  int get travelId;
+  @override
+  String get inviteeId;
+  @override
+  String get invitorId;
+
+  /// Create a copy of TravelParticipantModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$TravelParticipantModelImplCopyWith<_$TravelParticipantModelImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/application/lib/domain/travel/travel_model.freezed.dart
+++ b/application/lib/domain/travel/travel_model.freezed.dart
@@ -25,6 +25,7 @@ mixin _$TravelModel {
   DateTime get endedOn => throw _privateConstructorUsedError;
   AgeGroup? get ageGroup => throw _privateConstructorUsedError;
   Gender? get gender => throw _privateConstructorUsedError;
+  String? get memberId => throw _privateConstructorUsedError;
   List<TravelCompanionModel> get companions =>
       throw _privateConstructorUsedError;
   List<TravelMotivationType> get motivationTypes =>
@@ -53,6 +54,7 @@ abstract class $TravelModelCopyWith<$Res> {
       DateTime endedOn,
       AgeGroup? ageGroup,
       Gender? gender,
+      String? memberId,
       List<TravelCompanionModel> companions,
       List<TravelMotivationType> motivationTypes,
       List<CityModel> cities});
@@ -78,6 +80,7 @@ class _$TravelModelCopyWithImpl<$Res, $Val extends TravelModel>
     Object? endedOn = null,
     Object? ageGroup = freezed,
     Object? gender = freezed,
+    Object? memberId = freezed,
     Object? companions = null,
     Object? motivationTypes = null,
     Object? cities = null,
@@ -103,6 +106,10 @@ class _$TravelModelCopyWithImpl<$Res, $Val extends TravelModel>
           ? _value.gender
           : gender // ignore: cast_nullable_to_non_nullable
               as Gender?,
+      memberId: freezed == memberId
+          ? _value.memberId
+          : memberId // ignore: cast_nullable_to_non_nullable
+              as String?,
       companions: null == companions
           ? _value.companions
           : companions // ignore: cast_nullable_to_non_nullable
@@ -133,6 +140,7 @@ abstract class _$$TravelModelImplCopyWith<$Res>
       DateTime endedOn,
       AgeGroup? ageGroup,
       Gender? gender,
+      String? memberId,
       List<TravelCompanionModel> companions,
       List<TravelMotivationType> motivationTypes,
       List<CityModel> cities});
@@ -156,6 +164,7 @@ class __$$TravelModelImplCopyWithImpl<$Res>
     Object? endedOn = null,
     Object? ageGroup = freezed,
     Object? gender = freezed,
+    Object? memberId = freezed,
     Object? companions = null,
     Object? motivationTypes = null,
     Object? cities = null,
@@ -181,6 +190,10 @@ class __$$TravelModelImplCopyWithImpl<$Res>
           ? _value.gender
           : gender // ignore: cast_nullable_to_non_nullable
               as Gender?,
+      memberId: freezed == memberId
+          ? _value.memberId
+          : memberId // ignore: cast_nullable_to_non_nullable
+              as String?,
       companions: null == companions
           ? _value._companions
           : companions // ignore: cast_nullable_to_non_nullable
@@ -206,6 +219,7 @@ class _$TravelModelImpl extends _TravelModel {
       required this.endedOn,
       this.ageGroup,
       this.gender,
+      this.memberId,
       required final List<TravelCompanionModel> companions,
       required final List<TravelMotivationType> motivationTypes,
       required final List<CityModel> cities})
@@ -227,6 +241,8 @@ class _$TravelModelImpl extends _TravelModel {
   final AgeGroup? ageGroup;
   @override
   final Gender? gender;
+  @override
+  final String? memberId;
   final List<TravelCompanionModel> _companions;
   @override
   List<TravelCompanionModel> get companions {
@@ -253,7 +269,7 @@ class _$TravelModelImpl extends _TravelModel {
 
   @override
   String toString() {
-    return 'TravelModel(id: $id, startedOn: $startedOn, endedOn: $endedOn, ageGroup: $ageGroup, gender: $gender, companions: $companions, motivationTypes: $motivationTypes, cities: $cities)';
+    return 'TravelModel(id: $id, startedOn: $startedOn, endedOn: $endedOn, ageGroup: $ageGroup, gender: $gender, memberId: $memberId, companions: $companions, motivationTypes: $motivationTypes, cities: $cities)';
   }
 
   @override
@@ -268,6 +284,8 @@ class _$TravelModelImpl extends _TravelModel {
             (identical(other.ageGroup, ageGroup) ||
                 other.ageGroup == ageGroup) &&
             (identical(other.gender, gender) || other.gender == gender) &&
+            (identical(other.memberId, memberId) ||
+                other.memberId == memberId) &&
             const DeepCollectionEquality()
                 .equals(other._companions, _companions) &&
             const DeepCollectionEquality()
@@ -284,6 +302,7 @@ class _$TravelModelImpl extends _TravelModel {
       endedOn,
       ageGroup,
       gender,
+      memberId,
       const DeepCollectionEquality().hash(_companions),
       const DeepCollectionEquality().hash(_motivationTypes),
       const DeepCollectionEquality().hash(_cities));
@@ -311,6 +330,7 @@ abstract class _TravelModel extends TravelModel {
       required final DateTime endedOn,
       final AgeGroup? ageGroup,
       final Gender? gender,
+      final String? memberId,
       required final List<TravelCompanionModel> companions,
       required final List<TravelMotivationType> motivationTypes,
       required final List<CityModel> cities}) = _$TravelModelImpl;
@@ -329,6 +349,8 @@ abstract class _TravelModel extends TravelModel {
   AgeGroup? get ageGroup;
   @override
   Gender? get gender;
+  @override
+  String? get memberId;
   @override
   List<TravelCompanionModel> get companions;
   @override
@@ -787,7 +809,7 @@ mixin _$TravelParticipantModel {
   int get id => throw _privateConstructorUsedError;
   int get travelId => throw _privateConstructorUsedError;
   String get inviteeId => throw _privateConstructorUsedError;
-  String get invitorId => throw _privateConstructorUsedError;
+  String get inviterId => throw _privateConstructorUsedError;
 
   /// Serializes this TravelParticipantModel to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -805,7 +827,7 @@ abstract class $TravelParticipantModelCopyWith<$Res> {
           $Res Function(TravelParticipantModel) then) =
       _$TravelParticipantModelCopyWithImpl<$Res, TravelParticipantModel>;
   @useResult
-  $Res call({int id, int travelId, String inviteeId, String invitorId});
+  $Res call({int id, int travelId, String inviteeId, String inviterId});
 }
 
 /// @nodoc
@@ -827,7 +849,7 @@ class _$TravelParticipantModelCopyWithImpl<$Res,
     Object? id = null,
     Object? travelId = null,
     Object? inviteeId = null,
-    Object? invitorId = null,
+    Object? inviterId = null,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -842,9 +864,9 @@ class _$TravelParticipantModelCopyWithImpl<$Res,
           ? _value.inviteeId
           : inviteeId // ignore: cast_nullable_to_non_nullable
               as String,
-      invitorId: null == invitorId
-          ? _value.invitorId
-          : invitorId // ignore: cast_nullable_to_non_nullable
+      inviterId: null == inviterId
+          ? _value.inviterId
+          : inviterId // ignore: cast_nullable_to_non_nullable
               as String,
     ) as $Val);
   }
@@ -859,7 +881,7 @@ abstract class _$$TravelParticipantModelImplCopyWith<$Res>
       __$$TravelParticipantModelImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({int id, int travelId, String inviteeId, String invitorId});
+  $Res call({int id, int travelId, String inviteeId, String inviterId});
 }
 
 /// @nodoc
@@ -880,7 +902,7 @@ class __$$TravelParticipantModelImplCopyWithImpl<$Res>
     Object? id = null,
     Object? travelId = null,
     Object? inviteeId = null,
-    Object? invitorId = null,
+    Object? inviterId = null,
   }) {
     return _then(_$TravelParticipantModelImpl(
       id: null == id
@@ -895,9 +917,9 @@ class __$$TravelParticipantModelImplCopyWithImpl<$Res>
           ? _value.inviteeId
           : inviteeId // ignore: cast_nullable_to_non_nullable
               as String,
-      invitorId: null == invitorId
-          ? _value.invitorId
-          : invitorId // ignore: cast_nullable_to_non_nullable
+      inviterId: null == inviterId
+          ? _value.inviterId
+          : inviterId // ignore: cast_nullable_to_non_nullable
               as String,
     ));
   }
@@ -910,7 +932,7 @@ class _$TravelParticipantModelImpl implements _TravelParticipantModel {
       {required this.id,
       required this.travelId,
       required this.inviteeId,
-      required this.invitorId});
+      required this.inviterId});
 
   factory _$TravelParticipantModelImpl.fromJson(Map<String, dynamic> json) =>
       _$$TravelParticipantModelImplFromJson(json);
@@ -922,11 +944,11 @@ class _$TravelParticipantModelImpl implements _TravelParticipantModel {
   @override
   final String inviteeId;
   @override
-  final String invitorId;
+  final String inviterId;
 
   @override
   String toString() {
-    return 'TravelParticipantModel(id: $id, travelId: $travelId, inviteeId: $inviteeId, invitorId: $invitorId)';
+    return 'TravelParticipantModel(id: $id, travelId: $travelId, inviteeId: $inviteeId, inviterId: $inviterId)';
   }
 
   @override
@@ -939,14 +961,14 @@ class _$TravelParticipantModelImpl implements _TravelParticipantModel {
                 other.travelId == travelId) &&
             (identical(other.inviteeId, inviteeId) ||
                 other.inviteeId == inviteeId) &&
-            (identical(other.invitorId, invitorId) ||
-                other.invitorId == invitorId));
+            (identical(other.inviterId, inviterId) ||
+                other.inviterId == inviterId));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
-      Object.hash(runtimeType, id, travelId, inviteeId, invitorId);
+      Object.hash(runtimeType, id, travelId, inviteeId, inviterId);
 
   /// Create a copy of TravelParticipantModel
   /// with the given fields replaced by the non-null parameter values.
@@ -970,7 +992,7 @@ abstract class _TravelParticipantModel implements TravelParticipantModel {
       {required final int id,
       required final int travelId,
       required final String inviteeId,
-      required final String invitorId}) = _$TravelParticipantModelImpl;
+      required final String inviterId}) = _$TravelParticipantModelImpl;
 
   factory _TravelParticipantModel.fromJson(Map<String, dynamic> json) =
       _$TravelParticipantModelImpl.fromJson;
@@ -982,7 +1004,7 @@ abstract class _TravelParticipantModel implements TravelParticipantModel {
   @override
   String get inviteeId;
   @override
-  String get invitorId;
+  String get inviterId;
 
   /// Create a copy of TravelParticipantModel
   /// with the given fields replaced by the non-null parameter values.

--- a/application/lib/domain/travel/travel_model.g.dart
+++ b/application/lib/domain/travel/travel_model.g.dart
@@ -13,6 +13,7 @@ _$TravelModelImpl _$$TravelModelImplFromJson(Map<String, dynamic> json) =>
       endedOn: DateTime.parse(json['endedOn'] as String),
       ageGroup: $enumDecodeNullable(_$AgeGroupEnumMap, json['ageGroup']),
       gender: $enumDecodeNullable(_$GenderEnumMap, json['gender']),
+      memberId: json['memberId'] as String?,
       companions: (json['companions'] as List<dynamic>)
           .map((e) => TravelCompanionModel.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -31,6 +32,7 @@ Map<String, dynamic> _$$TravelModelImplToJson(_$TravelModelImpl instance) =>
       'endedOn': instance.endedOn.toIso8601String(),
       'ageGroup': _$AgeGroupEnumMap[instance.ageGroup],
       'gender': _$GenderEnumMap[instance.gender],
+      'memberId': instance.memberId,
       'companions': instance.companions,
       'motivationTypes': instance.motivationTypes
           .map((e) => _$TravelMotivationTypeEnumMap[e]!)
@@ -47,7 +49,6 @@ const _$AgeGroupEnumMap = {
   AgeGroup.fifties: 'fifties',
   AgeGroup.sixties: 'sixties',
   AgeGroup.seventiesPlus: 'seventiesPlus',
-  AgeGroup.none: 'none',
 };
 
 const _$GenderEnumMap = {
@@ -106,7 +107,7 @@ _$TravelParticipantModelImpl _$$TravelParticipantModelImplFromJson(
       id: (json['id'] as num).toInt(),
       travelId: (json['travelId'] as num).toInt(),
       inviteeId: json['inviteeId'] as String,
-      invitorId: json['invitorId'] as String,
+      inviterId: json['inviterId'] as String,
     );
 
 Map<String, dynamic> _$$TravelParticipantModelImplToJson(
@@ -115,5 +116,5 @@ Map<String, dynamic> _$$TravelParticipantModelImplToJson(
       'id': instance.id,
       'travelId': instance.travelId,
       'inviteeId': instance.inviteeId,
-      'invitorId': instance.invitorId,
+      'inviterId': instance.inviterId,
     };

--- a/application/lib/domain/travel/travel_model.g.dart
+++ b/application/lib/domain/travel/travel_model.g.dart
@@ -99,3 +99,21 @@ const _$TravelCompanionTypeEnumMap = {
   TravelCompanionType.members: 'members',
   TravelCompanionType.others: 'others',
 };
+
+_$TravelParticipantModelImpl _$$TravelParticipantModelImplFromJson(
+        Map<String, dynamic> json) =>
+    _$TravelParticipantModelImpl(
+      id: (json['id'] as num).toInt(),
+      travelId: (json['travelId'] as num).toInt(),
+      inviteeId: json['inviteeId'] as String,
+      invitorId: json['invitorId'] as String,
+    );
+
+Map<String, dynamic> _$$TravelParticipantModelImplToJson(
+        _$TravelParticipantModelImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'travelId': instance.travelId,
+      'inviteeId': instance.inviteeId,
+      'invitorId': instance.invitorId,
+    };

--- a/application/lib/feature/authentication/model/auth_model.dart
+++ b/application/lib/feature/authentication/model/auth_model.dart
@@ -3,13 +3,13 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'auth_model.freezed.dart';
 part 'auth_model.g.dart';
 
-
 @freezed
 class AuthModel with _$AuthModel {
-  const factory AuthModel(
-      {required String accessToken,
-      required String refreshToken,
-      required DateTime expiresAt}) = _AuthModel;
+  const factory AuthModel({
+    required String accessToken,
+    required String refreshToken,
+    required DateTime expiresAt,
+  }) = _AuthModel;
 
   factory AuthModel.fromJson(Map<String, dynamic> json) =>
       _$AuthModelFromJson(json);

--- a/application/lib/feature/authentication/page/login_provider.dart
+++ b/application/lib/feature/authentication/page/login_provider.dart
@@ -3,19 +3,21 @@ import 'dart:ffi';
 import 'package:application_new/common/exception/exception.dart';
 import 'package:application_new/common/loading/async_loading_provider.dart';
 import 'package:application_new/common/session/session_provider.dart';
+import 'package:application_new/domain/member/member_model.dart';
+import 'package:application_new/feature/authentication/model/auth_model.dart';
 import 'package:application_new/feature/authentication/model/auth_provider.dart';
 import 'package:application_new/feature/authentication/repository/auth_repository_provider.dart';
 import 'package:application_new/feature/authentication/service/auth_service_provider.dart';
+import 'package:jwt_decoder/jwt_decoder.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'login_provider.g.dart';
-
 
 @riverpod
 class Login extends _$Login {
   @override
   void build() {
-    return ;
+    return;
   }
 
   Future<void> login({required AuthProvider provider}) async {
@@ -24,11 +26,17 @@ class Login extends _$Login {
     final loadingNotifier = ref.read(asyncLoadingProvider.notifier);
 
     loadingNotifier.guard(() async {
-        await authService.login(
-          provider: provider.getName(),
-          authorizationCode: await provider.authorize(),
-        );
-        sessionNotifier.update(isAuthenticated: true);
+      await authService.login(
+        provider: provider.getName(),
+        authorizationCode: await provider.authorize(),
+      );
+
+      final AuthModel(:accessToken) = await authService.find();
+
+      final claims = JwtDecoder.decode(accessToken);
+      final member = MemberModel(id: claims['sub'] as String);
+
+      sessionNotifier.update(isAuthenticated: true, member: member);
     });
   }
 

--- a/application/lib/feature/authentication/page/login_provider.g.dart
+++ b/application/lib/feature/authentication/page/login_provider.g.dart
@@ -6,7 +6,7 @@ part of 'login_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$loginHash() => r'553339d085d44e3368f23138ed715f3090b37ef1';
+String _$loginHash() => r'494b670bb91dcdf70833c0b8a4600a1c073c9a67';
 
 /// See also [Login].
 @ProviderFor(Login)

--- a/application/lib/feature/travel_plan/page/travel_plan_home_page.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_home_page.dart
@@ -1,9 +1,11 @@
+import 'package:application_new/common/router/router_provider.dart';
 import 'package:application_new/common/util/translation_util.dart';
 import 'package:application_new/feature/travel_plan/component/travel_info_list_item.dart';
 import 'package:application_new/feature/travel_plan/provider/travel_plan_provider.dart';
 import 'package:application_new/feature/travel_plan/provider/travel_plan_state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 class TravelPlanHomePage extends ConsumerWidget {
   final TravelPlanProvider provider;
@@ -73,6 +75,8 @@ class TravelPlanHomePage extends ConsumerWidget {
                       ])),
             ),
           ),
+          SliverToBoxAdapter(child: TextButton(onPressed: () => context.push(
+              '/travels/${travel.id}/participants'), child: Text('여행 일원')))
         ],
       ),
     );

--- a/application/lib/feature/travel_plan/page/travel_plan_page.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_page.dart
@@ -56,7 +56,6 @@ class _TravelPlanPageState extends ConsumerState<TravelPlanPage> {
           children: [
             TravelPlanHomePage(provider: travelPlanProvider(widget.travelId), state: state),
             TravelPlanRecommendPage(travelId: widget.travelId, cityId: cityId),
-            TravelPlanParticipantPage(provider:travelPlanProvider(widget.travelId), state: state),
             TravelPlanManagePage(travelId: widget.travelId),
             TravelPlanBookmarkPage(travelId: widget.travelId),
           ],
@@ -82,10 +81,6 @@ class _TravelPlanPageState extends ConsumerState<TravelPlanPage> {
                 selectedIcon: Icon(Icons.place),
                 icon: Icon(Icons.place_outlined),
                 label: '둘러보기'),
-            NavigationDestination(
-                selectedIcon: Icon(Icons.person),
-                icon: Icon(Icons.person_outline),
-                label: '팀원'),
             NavigationDestination(
                 selectedIcon: Icon(Icons.map),
                 icon: Icon(Icons.map_outlined),

--- a/application/lib/feature/travel_plan/page/travel_plan_participant/page/travel_plan_participant_page.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_participant/page/travel_plan_participant_page.dart
@@ -1,33 +1,33 @@
+import 'package:application_new/common/loading/loading_page.dart';
 import 'package:application_new/common/translation/translation_service.dart';
+import 'package:application_new/domain/member/member_provider.dart';
 import 'package:application_new/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_provider.dart';
+import 'package:application_new/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../provider/travel_plan_provider.dart';
-import '../../../provider/travel_plan_state.dart';
-
 class TravelPlanParticipantPage extends ConsumerWidget {
-  final TravelPlanProvider provider;
-  final TravelPlanState state;
+  final int travelId;
 
-  const TravelPlanParticipantPage(
-      {super.key, required this.provider, required this.state});
+  const TravelPlanParticipantPage({super.key, required this.travelId});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData(:colorScheme) = Theme.of(context);
-    final TravelPlanState(:travel) = state;
-
     final tr = ref.watch(translationServiceProvider);
 
+    final state = ref.watch(travelPlanParticipantProvider(travelId));
+    if (state == null) return const LoadingPage();
+
+    final TravelPlanParticipantState(:travel, :participants) = state;
 
     return Scaffold(
       appBar: AppBar(title: Text(travel.formattedName)),
-      body: SingleChildScrollView(
-        child: Column(
-          children: [
-            const SizedBox(height: 32.0),
-            Container(
+      body: CustomScrollView(
+        slivers: [
+          const SliverToBoxAdapter(child: SizedBox(height: 32.0)),
+          SliverToBoxAdapter(
+            child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 24.0),
               width: double.maxFinite,
               child: Column(
@@ -44,20 +44,37 @@ class TravelPlanParticipantPage extends ConsumerWidget {
                   Text(tr.from('can_plan_with_participants')),
                   const SizedBox(height: 16.0),
                   FilledButton.icon(
-                    onPressed: () => ref.read(travelPlanParticipantProvider(travel.id).notifier).invite(),
+                    onPressed: () => ref
+                        .read(travelPlanParticipantProvider(travel.id).notifier)
+                        .shareLink(),
                     label: Text(tr.from('share_invitation_link')),
                     icon: const Icon(Icons.link),
                   )
                 ],
               ),
             ),
-            Container(
+          ),
+          SliverToBoxAdapter(
+            child: Container(
               margin: const EdgeInsets.symmetric(vertical: 32.0),
               color: colorScheme.surfaceContainer,
               height: 8.0,
             ),
-          ],
-        ),
+          ),
+          SliverList.builder(
+              itemCount: participants.length,
+              itemBuilder: (context, index) {
+                final participant = participants[index];
+
+                final invitee =
+                    ref.watch(memberProvider(participant.inviteeId)).value;
+
+                return ListTile(
+                  leading: const CircleAvatar(backgroundColor: Colors.red,),
+                  title: Text(invitee?.id.toString() ?? ''),
+                );
+              })
+        ],
       ),
     );
   }

--- a/application/lib/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_provider.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_provider.dart
@@ -56,4 +56,18 @@ class TravelPlanParticipant extends _$TravelPlanParticipant {
 
     Share.share(uri.toString(), subject: '초대 링크 공유하기');
   }
+
+  Future<void> leaveOrKick(int participantId) async {
+    await ref.read(asyncLoadingProvider.notifier).guard(() async {
+      final auth = await ref.read(authServiceProvider).find();
+
+      await ref.read(httpServiceProvider).request(
+            'DELETE',
+            '/api/v2/travels/$travelId/participants/$participantId',
+            authorization: auth.accessToken,
+          );
+    });
+
+    state = state?.copyWith(participants: await _fetch());
+  }
 }

--- a/application/lib/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_provider.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_provider.dart
@@ -1,5 +1,7 @@
 import 'package:application_new/common/http/http_service_provider.dart';
 import 'package:application_new/common/loading/async_loading_provider.dart';
+import 'package:application_new/domain/travel/travel_model.dart';
+import 'package:application_new/domain/travel/travel_provider.dart';
 import 'package:application_new/domain/travel_invitation/travel_invitation_model.dart';
 import 'package:application_new/feature/authentication/service/auth_service_provider.dart';
 import 'package:application_new/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_state.dart';
@@ -10,15 +12,30 @@ part 'travel_plan_participant_provider.g.dart';
 
 @riverpod
 class TravelPlanParticipant extends _$TravelPlanParticipant {
-
   static const String domain = String.fromEnvironment('DOMAIN');
 
   @override
   TravelPlanParticipantState? build(int travelId) {
+    final travel = ref.watch(travelProvider(travelId)).value;
+
+    if (travel == null) return null;
+
+    _fetch().then((participants) => state =
+        TravelPlanParticipantState(travel: travel, participants: participants));
+
     return null;
   }
 
-  Future<void> invite() async {
+  Future<List<TravelParticipantModel>> _fetch() async {
+    final httpService = ref.watch(httpServiceProvider);
+
+    final response = await httpService.request(
+        'GET', '/api/v2/travels/$travelId/participants');
+
+    return TravelParticipantModel.listFromJson(response);
+  }
+
+  Future<void> shareLink() async {
     final invitation =
         await ref.read(asyncLoadingProvider.notifier).guard(() async {
       final auth = await ref.read(authServiceProvider).find();
@@ -32,7 +49,10 @@ class TravelPlanParticipant extends _$TravelPlanParticipant {
       return TravelInvitationModel.fromJson(response['invitation']);
     });
 
-    final uri = Uri(scheme: 'https', host: domain, path: '/travels/${invitation.travelId}/invitations/${invitation.id}');
+    final uri = Uri(
+        scheme: 'https',
+        host: domain,
+        path: '/travels/${invitation.travelId}/invitations/${invitation.id}');
 
     Share.share(uri.toString(), subject: '초대 링크 공유하기');
   }

--- a/application/lib/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_provider.g.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_provider.g.dart
@@ -7,7 +7,7 @@ part of 'travel_plan_participant_provider.dart';
 // **************************************************************************
 
 String _$travelPlanParticipantHash() =>
-    r'ee23da266c68d51a5233ebdfc66b9f2ba7766edc';
+    r'86dde68af26b388c4ac8fd510149cfa91da19742';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/application/lib/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_provider.g.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_provider.g.dart
@@ -7,7 +7,7 @@ part of 'travel_plan_participant_provider.dart';
 // **************************************************************************
 
 String _$travelPlanParticipantHash() =>
-    r'7706f47f22dd5fde3549aff2a558fdd41f4e3e53';
+    r'ee23da266c68d51a5233ebdfc66b9f2ba7766edc';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/application/lib/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_state.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_state.dart
@@ -1,3 +1,4 @@
+import 'package:application_new/domain/travel/travel_model.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'travel_plan_participant_state.freezed.dart';
@@ -5,6 +6,9 @@ part 'travel_plan_participant_state.freezed.dart';
 @freezed
 class TravelPlanParticipantState with _$TravelPlanParticipantState {
 
-  const factory TravelPlanParticipantState() = _TravelPlanParticipantState;
+  const factory TravelPlanParticipantState({
+    required TravelModel travel,
+    required List<TravelParticipantModel> participants,
+  }) = _TravelPlanParticipantState;
 
 }

--- a/application/lib/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_state.freezed.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_participant/provider/travel_plan_participant_state.freezed.dart
@@ -15,7 +15,17 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
-mixin _$TravelPlanParticipantState {}
+mixin _$TravelPlanParticipantState {
+  TravelModel get travel => throw _privateConstructorUsedError;
+  List<TravelParticipantModel> get participants =>
+      throw _privateConstructorUsedError;
+
+  /// Create a copy of TravelPlanParticipantState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $TravelPlanParticipantStateCopyWith<TravelPlanParticipantState>
+      get copyWith => throw _privateConstructorUsedError;
+}
 
 /// @nodoc
 abstract class $TravelPlanParticipantStateCopyWith<$Res> {
@@ -23,6 +33,10 @@ abstract class $TravelPlanParticipantStateCopyWith<$Res> {
           $Res Function(TravelPlanParticipantState) then) =
       _$TravelPlanParticipantStateCopyWithImpl<$Res,
           TravelPlanParticipantState>;
+  @useResult
+  $Res call({TravelModel travel, List<TravelParticipantModel> participants});
+
+  $TravelModelCopyWith<$Res> get travel;
 }
 
 /// @nodoc
@@ -38,14 +52,48 @@ class _$TravelPlanParticipantStateCopyWithImpl<$Res,
 
   /// Create a copy of TravelPlanParticipantState
   /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? travel = null,
+    Object? participants = null,
+  }) {
+    return _then(_value.copyWith(
+      travel: null == travel
+          ? _value.travel
+          : travel // ignore: cast_nullable_to_non_nullable
+              as TravelModel,
+      participants: null == participants
+          ? _value.participants
+          : participants // ignore: cast_nullable_to_non_nullable
+              as List<TravelParticipantModel>,
+    ) as $Val);
+  }
+
+  /// Create a copy of TravelPlanParticipantState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $TravelModelCopyWith<$Res> get travel {
+    return $TravelModelCopyWith<$Res>(_value.travel, (value) {
+      return _then(_value.copyWith(travel: value) as $Val);
+    });
+  }
 }
 
 /// @nodoc
-abstract class _$$TravelPlanParticipantStateImplCopyWith<$Res> {
+abstract class _$$TravelPlanParticipantStateImplCopyWith<$Res>
+    implements $TravelPlanParticipantStateCopyWith<$Res> {
   factory _$$TravelPlanParticipantStateImplCopyWith(
           _$TravelPlanParticipantStateImpl value,
           $Res Function(_$TravelPlanParticipantStateImpl) then) =
       __$$TravelPlanParticipantStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({TravelModel travel, List<TravelParticipantModel> participants});
+
+  @override
+  $TravelModelCopyWith<$Res> get travel;
 }
 
 /// @nodoc
@@ -60,31 +108,88 @@ class __$$TravelPlanParticipantStateImplCopyWithImpl<$Res>
 
   /// Create a copy of TravelPlanParticipantState
   /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? travel = null,
+    Object? participants = null,
+  }) {
+    return _then(_$TravelPlanParticipantStateImpl(
+      travel: null == travel
+          ? _value.travel
+          : travel // ignore: cast_nullable_to_non_nullable
+              as TravelModel,
+      participants: null == participants
+          ? _value._participants
+          : participants // ignore: cast_nullable_to_non_nullable
+              as List<TravelParticipantModel>,
+    ));
+  }
 }
 
 /// @nodoc
 
 class _$TravelPlanParticipantStateImpl implements _TravelPlanParticipantState {
-  const _$TravelPlanParticipantStateImpl();
+  const _$TravelPlanParticipantStateImpl(
+      {required this.travel,
+      required final List<TravelParticipantModel> participants})
+      : _participants = participants;
+
+  @override
+  final TravelModel travel;
+  final List<TravelParticipantModel> _participants;
+  @override
+  List<TravelParticipantModel> get participants {
+    if (_participants is EqualUnmodifiableListView) return _participants;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_participants);
+  }
 
   @override
   String toString() {
-    return 'TravelPlanParticipantState()';
+    return 'TravelPlanParticipantState(travel: $travel, participants: $participants)';
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$TravelPlanParticipantStateImpl);
+            other is _$TravelPlanParticipantStateImpl &&
+            (identical(other.travel, travel) || other.travel == travel) &&
+            const DeepCollectionEquality()
+                .equals(other._participants, _participants));
   }
 
   @override
-  int get hashCode => runtimeType.hashCode;
+  int get hashCode => Object.hash(
+      runtimeType, travel, const DeepCollectionEquality().hash(_participants));
+
+  /// Create a copy of TravelPlanParticipantState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TravelPlanParticipantStateImplCopyWith<_$TravelPlanParticipantStateImpl>
+      get copyWith => __$$TravelPlanParticipantStateImplCopyWithImpl<
+          _$TravelPlanParticipantStateImpl>(this, _$identity);
 }
 
 abstract class _TravelPlanParticipantState
     implements TravelPlanParticipantState {
-  const factory _TravelPlanParticipantState() =
+  const factory _TravelPlanParticipantState(
+          {required final TravelModel travel,
+          required final List<TravelParticipantModel> participants}) =
       _$TravelPlanParticipantStateImpl;
+
+  @override
+  TravelModel get travel;
+  @override
+  List<TravelParticipantModel> get participants;
+
+  /// Create a copy of TravelPlanParticipantState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$TravelPlanParticipantStateImplCopyWith<_$TravelPlanParticipantStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/application/lib/feature/travel_plan/page/travel_plan_recommend/component/travel_item.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_recommend/component/travel_item.dart
@@ -55,7 +55,7 @@ class TravelItem extends ConsumerWidget {
                         textStyle: const TextStyle(
                             fontSize: 12.0, fontWeight: FontWeight.w600),
                         backgroundColor: colorScheme.surface),
-                    child: Text(tr.from('view_travelogues')))),
+                    child: Text(tr.from('read_travelogues')))),
             const SizedBox(width: 8.0),
             Expanded(
               flex: 1,

--- a/application/lib/main.dart
+++ b/application/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:application_new/common/event/event.dart';
 import 'package:application_new/common/loading/async_loading_provider.dart';
 import 'package:application_new/common/session/session_provider.dart';
 import 'package:application_new/common/translation/translation_service.dart';
+import 'package:application_new/feature/authentication/model/auth_model.dart';
 import 'package:application_new/feature/authentication/service/auth_service_provider.dart';
 import 'package:application_new/feature/locale/locale_provider.dart';
 import 'package:application_new/shared/theme/my_chip_theme.dart';
@@ -15,11 +16,13 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:easy_localization_loader/easy_localization_loader.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jwt_decoder/jwt_decoder.dart';
 import 'package:logger/logger.dart';
 import 'package:uuid/v4.dart';
 
 import 'common/exception/exception.dart';
 import 'common/router/router_provider.dart';
+import 'domain/member/member_model.dart';
 
 final messengerKey = GlobalKey<ScaffoldMessengerState>();
 
@@ -131,8 +134,11 @@ class _MyAppState extends ConsumerState<MyApp> {
     final authService = ref.read(authServiceProvider);
     final sessionNotifier = ref.read(sessionProvider.notifier);
 
-    await authService.find();
-    sessionNotifier.update(isAuthenticated: true);
+    final AuthModel(:accessToken) = await authService.find();
+
+    final claims = JwtDecoder.decode(accessToken);
+    final member = MemberModel(id: claims['sub'] as String);
+    sessionNotifier.update(isAuthenticated: true, member: member);
   }
 
   @override

--- a/application/lib/shared/model/member_model.dart
+++ b/application/lib/shared/model/member_model.dart
@@ -6,8 +6,7 @@ enum AgeGroup {
   forties,
   fifties,
   sixties,
-  seventiesPlus,
-  none
+  seventiesPlus
 }
 
 enum Gender {

--- a/application/pubspec.lock
+++ b/application/pubspec.lock
@@ -666,6 +666,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.8.0"
+  jwt_decoder:
+    dependency: "direct main"
+    description:
+      name: jwt_decoder
+      sha256: "54774aebf83f2923b99e6416b4ea915d47af3bde56884eb622de85feabbc559f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   latlong2:
     dependency: transitive
     description:

--- a/application/pubspec.yaml
+++ b/application/pubspec.yaml
@@ -64,6 +64,7 @@ dependencies:
   animations: ^2.0.11
   share_plus: ^10.1.2
   share_plus_platform_interface: ^5.0.1
+  jwt_decoder: ^2.0.1
 
 dev_dependencies:
   flutter_test:

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/controller/MemberController.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/controller/MemberController.java
@@ -1,0 +1,25 @@
+package com.yeohaeng_ttukttak.server.application.member.controller;
+
+import com.yeohaeng_ttukttak.server.application.member.controller.dto.FindMemberResponse;
+import com.yeohaeng_ttukttak.server.application.member.service.FindMemberService;
+import com.yeohaeng_ttukttak.server.common.dto.ServerResponse;
+import com.yeohaeng_ttukttak.server.domain.member.dto.MemberDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v2/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final FindMemberService findMemberService;
+
+    @GetMapping("/{id}")
+    public ServerResponse<FindMemberResponse> find(@PathVariable String id) {
+        final MemberDto dto = findMemberService.findOne(id);
+        return new ServerResponse<>(new FindMemberResponse(dto));
+    }
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/controller/dto/FindMemberResponse.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/controller/dto/FindMemberResponse.java
@@ -1,0 +1,5 @@
+package com.yeohaeng_ttukttak.server.application.member.controller.dto;
+
+import com.yeohaeng_ttukttak.server.domain.member.dto.MemberDto;
+
+public record FindMemberResponse(MemberDto member) { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/service/FindMemberService.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/service/FindMemberService.java
@@ -1,0 +1,22 @@
+package com.yeohaeng_ttukttak.server.application.member.service;
+
+import com.yeohaeng_ttukttak.server.domain.member.dto.MemberDto;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Member;
+import com.yeohaeng_ttukttak.server.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindMemberService {
+
+    private final MemberService memberService;
+
+    public MemberDto findOne(String memberId) {
+        final Member member = memberService.find(memberId);
+        return MemberDto.of(member);
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/dto/MemberDto.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/dto/MemberDto.java
@@ -1,0 +1,18 @@
+package com.yeohaeng_ttukttak.server.domain.member.dto;
+
+import com.yeohaeng_ttukttak.server.domain.member.entity.AgeGroup;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Gender;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Member;
+
+public record MemberDto(
+        String id,
+        AgeGroup ageGroup,
+        Gender gender
+) {
+
+    public static MemberDto of(Member member) {
+        return new MemberDto(
+                member.id(), member.ageGroup(), member.gender());
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/Member.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/Member.java
@@ -1,6 +1,5 @@
 package com.yeohaeng_ttukttak.server.domain.member.entity;
 
-import com.yeohaeng_ttukttak.server.domain.auth.dto.AuthorizationDto;
 import com.yeohaeng_ttukttak.server.domain.oauth.entity.OAuth;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/service/MemberService.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.yeohaeng_ttukttak.server.domain.member.service;
 
 import com.yeohaeng_ttukttak.server.common.exception.exception.error.AuthorizationErrorException;
+import com.yeohaeng_ttukttak.server.common.exception.exception.fail.EntityNotFoundFailException;
 import com.yeohaeng_ttukttak.server.domain.member.entity.Member;
 import com.yeohaeng_ttukttak.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +18,7 @@ public class MemberService {
     public Member find(String memberId) {
         return repository
                 .findById(UUID.fromString(memberId))
-                .orElseThrow(AuthorizationErrorException::new);
+                .orElseThrow(() -> new EntityNotFoundFailException(Member.class));
     }
 
 

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/dto/TravelDto.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel/dto/TravelDto.java
@@ -14,18 +14,24 @@ public record TravelDto(
         LocalDate endedOn,
         AgeGroup ageGroup,
         Gender gender,
+        String memberId,
         List<TravelCompanionDto> companions,
         List<TravelMotivationType> motivationTypes,
         List<CityDto> cities
 ) {
 
     public static TravelDto of(Travel travel) {
+        final String memberId = travel instanceof MemberTravel
+                ? ((MemberTravel) travel).member().id()
+                : null;
+
         return new TravelDto(
                 travel.id(),
                 travel.startedOn(),
                 travel.endedOn(),
                 travel.ageGroup(),
                 travel.gender(),
+                memberId,
                 travel.companions().stream()
                         .map(TravelCompanionDto::of)
                         .toList(),


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> Ex. close #이슈 번호, #이슈 번호

추방 "기능" 연결은 끝났으니 해당 이슈는 닫습니다. UI는 추후 보완할 필요가 있습니다.

close #7 

<br/>

## 📝 작업 내용
> 작업한 내용을 간략히 설명해 주세요.

- [x] 번역 키 오타 수정, `Enum` 값을 번역 메서드 구현
- [x] 사용자 조회 API 구현
- [x] 여행 참여자 UI 구현 및 추방 기능 구현

<br/>

## ✅ 작업 결과
> 작업 내용 Notion 링크, 혹은 이미지를 첨부해 주세요.

## 💬 추가 사항 (선택)
> 추가로 기재할 사항이 있으면 기재해 주세요.

현재 사용자 닉네임이 부여되지 않아, 임시로 닉네임을 랜덤 생성해 사용했습니다. 추후, 가입 시 랜덤으로 `UID` 혹은 닉네임을 부여해야 합니다.
- **짧은 식별 코드나 닉네임을 "필수로" 부여**해야 합니다.
- `OAuth` 혹은 사용자 입력으로 성별 및 연령대 데이터를 입력받아야 합니다.

<br/>

또한, 여행 데이터셋의 데이터를 별도 **도메인으로 분리하는걸 고려**해봐야 합니다.
- 여행(`Travel`) 도메인은 사용자 동작(생성/수정/삭제)을 수행하고, 여행지 추천, 계획 추가 등 읽고/쓰기 둘 다 가능해야 합니다.
- 여행 데이터셋은 오직 여행지 추천, 여행기 읽기 등의 읽기 동작만 수행합니다.

처음에는 두 객체가 같다고 생각했는데, 실제 구현 및 사용해 보니 두 객체를 서로 다른 도메인으로 분리해야 한다고 생각합니다.