### PR TITLE
Feature(#3): 애플리케이션 프로필 UI 및 수정 기능 구현

### DIFF
--- a/application/assets/translations/en.yaml
+++ b/application/assets/translations/en.yaml
@@ -57,6 +57,8 @@ please_log_in: Please Log in.
 
 please_enter_nickname: Please enter a nickname.
 
+profile_has_been_edited: The profile was updated successfully.
+
 gender: Gender
 age_group: Age Group
 nickname: Nickname

--- a/application/assets/translations/en.yaml
+++ b/application/assets/translations/en.yaml
@@ -55,6 +55,13 @@ edit_profile: Edit profile
 travel_participants: Travel participants
 please_log_in: Please Log in.
 
+please_enter_nickname: Please enter a nickname.
+
+gender: Gender
+age_group: Age Group
+nickname: Nickname
+edit_complete: Edit complete
+
 widget:
   VisitListItem:
     ask_reason: Why did you visit this place?

--- a/application/assets/translations/en.yaml
+++ b/application/assets/translations/en.yaml
@@ -51,7 +51,9 @@ retry: Retry
 leave: Leave
 kick: Kick
 
+edit_profile: Edit profile
 travel_participants: Travel participants
+please_log_in: Please Log in.
 
 widget:
   VisitListItem:

--- a/application/assets/translations/ko.yaml
+++ b/application/assets/translations/ko.yaml
@@ -56,6 +56,12 @@ kick: 추방하기
 edit_profile: 프로필 수정
 travel_participants: 여행 일행
 please_log_in: 로그인해 주세요.
+please_enter_nickname: 닉네임을 입력해 주세요.
+
+gender: 성별
+age_group: 연령대
+nickname: 닉네임
+edit_complete: 수정 완료
 
 widget:
   VisitListItem:
@@ -139,21 +145,20 @@ enum:
   AgeGroup:
     name: 연령대
     values:
-      underNine: 9세이하
+      underNine: 9세 이하
       teens: 10대
       twenties: 20대
       thirties: 30대
       forties: 40대
       fifties: 50대
       sixties: 60대
-      seventiesPlus: 70세이상
-      other: 기타
+      seventiesPlus: 70세 이상
 
   Gender:
     name: 성별
     values:
-      male: Male
-      female: Female
+      male: 남성
+      female: 여성
       other: 기타
 
   TravelVisitReasonType:

--- a/application/assets/translations/ko.yaml
+++ b/application/assets/translations/ko.yaml
@@ -53,7 +53,9 @@ retry: 다시 시도하기
 leave: 떠나기
 kick: 추방하기
 
+edit_profile: 프로필 수정
 travel_participants: 여행 일행
+please_log_in: 로그인해 주세요.
 
 widget:
   VisitListItem:

--- a/application/assets/translations/ko.yaml
+++ b/application/assets/translations/ko.yaml
@@ -63,6 +63,8 @@ age_group: 연령대
 nickname: 닉네임
 edit_complete: 수정 완료
 
+profile_has_been_edited: 프로필이 성공적으로 수정되었습니다.
+
 widget:
   VisitListItem:
     ask_reason: 이곳을 방문한 이유는 무엇인가요?

--- a/application/lib/common/exception/exception.dart
+++ b/application/lib/common/exception/exception.dart
@@ -46,3 +46,12 @@ final class AuthorizationException extends BusinessException {
 
   AuthorizationException({this.message});
 }
+
+class ValidationException extends BusinessException {
+
+  final String target;
+  final String message;
+
+  ValidationException(this.target, this.message);
+
+}

--- a/application/lib/common/router/router_provider.dart
+++ b/application/lib/common/router/router_provider.dart
@@ -3,6 +3,7 @@ import 'package:application_new/common/session/session_provider.dart';
 import 'package:application_new/feature/authentication/page/login_page.dart';
 import 'package:application_new/feature/error/error_page.dart';
 import 'package:application_new/feature/home/home_page.dart';
+import 'package:application_new/feature/profile/profile_edit_page.dart';
 import 'package:application_new/feature/travel_create/page/travel_create_page.dart';
 import 'package:application_new/feature/travel_invitation/page/travel_invitation_page.dart';
 import 'package:application_new/feature/travel_plan/page/travel_plan_participant/page/travel_plan_participant_page.dart';
@@ -39,6 +40,9 @@ GoRouter router(RouterRef ref) {
       return ErrorPage(message: state.error?.message);
     },
     routes: [
+      GoRoute(
+          path: '/profile/edit',
+          builder: (context, state) => ProfileEditPage()),
       GoRoute(
           path: '/error',
           builder: (context, state) {

--- a/application/lib/common/router/router_provider.g.dart
+++ b/application/lib/common/router/router_provider.g.dart
@@ -6,7 +6,7 @@ part of 'router_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$routerHash() => r'64f6dea71b04b4e6cad7630048b67a0a383dc9d8';
+String _$routerHash() => r'11d7d86ab79f1ee8e9dacf2a4b847222d5c4402d';
 
 /// See also [router].
 @ProviderFor(router)

--- a/application/lib/domain/member/member_model.dart
+++ b/application/lib/domain/member/member_model.dart
@@ -9,6 +9,7 @@ class MemberModel with _$MemberModel {
   const factory MemberModel({
     required String uuid,
     required String nickname,
+    required AvatarModel avatar,
     AgeGroup? ageGroup,
     Gender? gender,
   }) = _MemberModel;
@@ -16,4 +17,17 @@ class MemberModel with _$MemberModel {
   factory MemberModel.fromJson(Map<String, dynamic> json) =>
       _$MemberModelFromJson(json);
 
+}
+
+@freezed
+class AvatarModel with _$AvatarModel {
+
+  const factory AvatarModel({
+    required String host,
+    required String path,
+    required String ext
+  }) = _AvatarModel;
+
+  factory AvatarModel.fromJson(Map<String, dynamic> json) =>
+      _$AvatarModelFromJson(json);
 }

--- a/application/lib/domain/member/member_model.freezed.dart
+++ b/application/lib/domain/member/member_model.freezed.dart
@@ -22,6 +22,7 @@ MemberModel _$MemberModelFromJson(Map<String, dynamic> json) {
 mixin _$MemberModel {
   String get uuid => throw _privateConstructorUsedError;
   String get nickname => throw _privateConstructorUsedError;
+  AvatarModel get avatar => throw _privateConstructorUsedError;
   AgeGroup? get ageGroup => throw _privateConstructorUsedError;
   Gender? get gender => throw _privateConstructorUsedError;
 
@@ -41,7 +42,14 @@ abstract class $MemberModelCopyWith<$Res> {
           MemberModel value, $Res Function(MemberModel) then) =
       _$MemberModelCopyWithImpl<$Res, MemberModel>;
   @useResult
-  $Res call({String uuid, String nickname, AgeGroup? ageGroup, Gender? gender});
+  $Res call(
+      {String uuid,
+      String nickname,
+      AvatarModel avatar,
+      AgeGroup? ageGroup,
+      Gender? gender});
+
+  $AvatarModelCopyWith<$Res> get avatar;
 }
 
 /// @nodoc
@@ -61,6 +69,7 @@ class _$MemberModelCopyWithImpl<$Res, $Val extends MemberModel>
   $Res call({
     Object? uuid = null,
     Object? nickname = null,
+    Object? avatar = null,
     Object? ageGroup = freezed,
     Object? gender = freezed,
   }) {
@@ -73,6 +82,10 @@ class _$MemberModelCopyWithImpl<$Res, $Val extends MemberModel>
           ? _value.nickname
           : nickname // ignore: cast_nullable_to_non_nullable
               as String,
+      avatar: null == avatar
+          ? _value.avatar
+          : avatar // ignore: cast_nullable_to_non_nullable
+              as AvatarModel,
       ageGroup: freezed == ageGroup
           ? _value.ageGroup
           : ageGroup // ignore: cast_nullable_to_non_nullable
@@ -82,6 +95,16 @@ class _$MemberModelCopyWithImpl<$Res, $Val extends MemberModel>
           : gender // ignore: cast_nullable_to_non_nullable
               as Gender?,
     ) as $Val);
+  }
+
+  /// Create a copy of MemberModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AvatarModelCopyWith<$Res> get avatar {
+    return $AvatarModelCopyWith<$Res>(_value.avatar, (value) {
+      return _then(_value.copyWith(avatar: value) as $Val);
+    });
   }
 }
 
@@ -93,7 +116,15 @@ abstract class _$$MemberModelImplCopyWith<$Res>
       __$$MemberModelImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String uuid, String nickname, AgeGroup? ageGroup, Gender? gender});
+  $Res call(
+      {String uuid,
+      String nickname,
+      AvatarModel avatar,
+      AgeGroup? ageGroup,
+      Gender? gender});
+
+  @override
+  $AvatarModelCopyWith<$Res> get avatar;
 }
 
 /// @nodoc
@@ -111,6 +142,7 @@ class __$$MemberModelImplCopyWithImpl<$Res>
   $Res call({
     Object? uuid = null,
     Object? nickname = null,
+    Object? avatar = null,
     Object? ageGroup = freezed,
     Object? gender = freezed,
   }) {
@@ -123,6 +155,10 @@ class __$$MemberModelImplCopyWithImpl<$Res>
           ? _value.nickname
           : nickname // ignore: cast_nullable_to_non_nullable
               as String,
+      avatar: null == avatar
+          ? _value.avatar
+          : avatar // ignore: cast_nullable_to_non_nullable
+              as AvatarModel,
       ageGroup: freezed == ageGroup
           ? _value.ageGroup
           : ageGroup // ignore: cast_nullable_to_non_nullable
@@ -139,7 +175,11 @@ class __$$MemberModelImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$MemberModelImpl implements _MemberModel {
   const _$MemberModelImpl(
-      {required this.uuid, required this.nickname, this.ageGroup, this.gender});
+      {required this.uuid,
+      required this.nickname,
+      required this.avatar,
+      this.ageGroup,
+      this.gender});
 
   factory _$MemberModelImpl.fromJson(Map<String, dynamic> json) =>
       _$$MemberModelImplFromJson(json);
@@ -149,13 +189,15 @@ class _$MemberModelImpl implements _MemberModel {
   @override
   final String nickname;
   @override
+  final AvatarModel avatar;
+  @override
   final AgeGroup? ageGroup;
   @override
   final Gender? gender;
 
   @override
   String toString() {
-    return 'MemberModel(uuid: $uuid, nickname: $nickname, ageGroup: $ageGroup, gender: $gender)';
+    return 'MemberModel(uuid: $uuid, nickname: $nickname, avatar: $avatar, ageGroup: $ageGroup, gender: $gender)';
   }
 
   @override
@@ -166,6 +208,7 @@ class _$MemberModelImpl implements _MemberModel {
             (identical(other.uuid, uuid) || other.uuid == uuid) &&
             (identical(other.nickname, nickname) ||
                 other.nickname == nickname) &&
+            (identical(other.avatar, avatar) || other.avatar == avatar) &&
             (identical(other.ageGroup, ageGroup) ||
                 other.ageGroup == ageGroup) &&
             (identical(other.gender, gender) || other.gender == gender));
@@ -174,7 +217,7 @@ class _$MemberModelImpl implements _MemberModel {
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode =>
-      Object.hash(runtimeType, uuid, nickname, ageGroup, gender);
+      Object.hash(runtimeType, uuid, nickname, avatar, ageGroup, gender);
 
   /// Create a copy of MemberModel
   /// with the given fields replaced by the non-null parameter values.
@@ -196,6 +239,7 @@ abstract class _MemberModel implements MemberModel {
   const factory _MemberModel(
       {required final String uuid,
       required final String nickname,
+      required final AvatarModel avatar,
       final AgeGroup? ageGroup,
       final Gender? gender}) = _$MemberModelImpl;
 
@@ -207,6 +251,8 @@ abstract class _MemberModel implements MemberModel {
   @override
   String get nickname;
   @override
+  AvatarModel get avatar;
+  @override
   AgeGroup? get ageGroup;
   @override
   Gender? get gender;
@@ -216,5 +262,190 @@ abstract class _MemberModel implements MemberModel {
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   _$$MemberModelImplCopyWith<_$MemberModelImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+AvatarModel _$AvatarModelFromJson(Map<String, dynamic> json) {
+  return _AvatarModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$AvatarModel {
+  String get host => throw _privateConstructorUsedError;
+  String get path => throw _privateConstructorUsedError;
+  String get ext => throw _privateConstructorUsedError;
+
+  /// Serializes this AvatarModel to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of AvatarModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AvatarModelCopyWith<AvatarModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AvatarModelCopyWith<$Res> {
+  factory $AvatarModelCopyWith(
+          AvatarModel value, $Res Function(AvatarModel) then) =
+      _$AvatarModelCopyWithImpl<$Res, AvatarModel>;
+  @useResult
+  $Res call({String host, String path, String ext});
+}
+
+/// @nodoc
+class _$AvatarModelCopyWithImpl<$Res, $Val extends AvatarModel>
+    implements $AvatarModelCopyWith<$Res> {
+  _$AvatarModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AvatarModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? host = null,
+    Object? path = null,
+    Object? ext = null,
+  }) {
+    return _then(_value.copyWith(
+      host: null == host
+          ? _value.host
+          : host // ignore: cast_nullable_to_non_nullable
+              as String,
+      path: null == path
+          ? _value.path
+          : path // ignore: cast_nullable_to_non_nullable
+              as String,
+      ext: null == ext
+          ? _value.ext
+          : ext // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$AvatarModelImplCopyWith<$Res>
+    implements $AvatarModelCopyWith<$Res> {
+  factory _$$AvatarModelImplCopyWith(
+          _$AvatarModelImpl value, $Res Function(_$AvatarModelImpl) then) =
+      __$$AvatarModelImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String host, String path, String ext});
+}
+
+/// @nodoc
+class __$$AvatarModelImplCopyWithImpl<$Res>
+    extends _$AvatarModelCopyWithImpl<$Res, _$AvatarModelImpl>
+    implements _$$AvatarModelImplCopyWith<$Res> {
+  __$$AvatarModelImplCopyWithImpl(
+      _$AvatarModelImpl _value, $Res Function(_$AvatarModelImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AvatarModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? host = null,
+    Object? path = null,
+    Object? ext = null,
+  }) {
+    return _then(_$AvatarModelImpl(
+      host: null == host
+          ? _value.host
+          : host // ignore: cast_nullable_to_non_nullable
+              as String,
+      path: null == path
+          ? _value.path
+          : path // ignore: cast_nullable_to_non_nullable
+              as String,
+      ext: null == ext
+          ? _value.ext
+          : ext // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$AvatarModelImpl implements _AvatarModel {
+  const _$AvatarModelImpl(
+      {required this.host, required this.path, required this.ext});
+
+  factory _$AvatarModelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AvatarModelImplFromJson(json);
+
+  @override
+  final String host;
+  @override
+  final String path;
+  @override
+  final String ext;
+
+  @override
+  String toString() {
+    return 'AvatarModel(host: $host, path: $path, ext: $ext)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AvatarModelImpl &&
+            (identical(other.host, host) || other.host == host) &&
+            (identical(other.path, path) || other.path == path) &&
+            (identical(other.ext, ext) || other.ext == ext));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, host, path, ext);
+
+  /// Create a copy of AvatarModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AvatarModelImplCopyWith<_$AvatarModelImpl> get copyWith =>
+      __$$AvatarModelImplCopyWithImpl<_$AvatarModelImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$AvatarModelImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _AvatarModel implements AvatarModel {
+  const factory _AvatarModel(
+      {required final String host,
+      required final String path,
+      required final String ext}) = _$AvatarModelImpl;
+
+  factory _AvatarModel.fromJson(Map<String, dynamic> json) =
+      _$AvatarModelImpl.fromJson;
+
+  @override
+  String get host;
+  @override
+  String get path;
+  @override
+  String get ext;
+
+  /// Create a copy of AvatarModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AvatarModelImplCopyWith<_$AvatarModelImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/application/lib/domain/member/member_model.g.dart
+++ b/application/lib/domain/member/member_model.g.dart
@@ -10,6 +10,7 @@ _$MemberModelImpl _$$MemberModelImplFromJson(Map<String, dynamic> json) =>
     _$MemberModelImpl(
       uuid: json['uuid'] as String,
       nickname: json['nickname'] as String,
+      avatar: AvatarModel.fromJson(json['avatar'] as Map<String, dynamic>),
       ageGroup: $enumDecodeNullable(_$AgeGroupEnumMap, json['ageGroup']),
       gender: $enumDecodeNullable(_$GenderEnumMap, json['gender']),
     );
@@ -18,6 +19,7 @@ Map<String, dynamic> _$$MemberModelImplToJson(_$MemberModelImpl instance) =>
     <String, dynamic>{
       'uuid': instance.uuid,
       'nickname': instance.nickname,
+      'avatar': instance.avatar,
       'ageGroup': _$AgeGroupEnumMap[instance.ageGroup],
       'gender': _$GenderEnumMap[instance.gender],
     };
@@ -37,3 +39,17 @@ const _$GenderEnumMap = {
   Gender.male: 'male',
   Gender.female: 'female',
 };
+
+_$AvatarModelImpl _$$AvatarModelImplFromJson(Map<String, dynamic> json) =>
+    _$AvatarModelImpl(
+      host: json['host'] as String,
+      path: json['path'] as String,
+      ext: json['ext'] as String,
+    );
+
+Map<String, dynamic> _$$AvatarModelImplToJson(_$AvatarModelImpl instance) =>
+    <String, dynamic>{
+      'host': instance.host,
+      'path': instance.path,
+      'ext': instance.ext,
+    };

--- a/application/lib/feature/authentication/page/login_page.dart
+++ b/application/lib/feature/authentication/page/login_page.dart
@@ -1,6 +1,7 @@
 
 import 'package:application_new/feature/authentication/model/auth_provider.dart';
 import 'package:application_new/feature/authentication/page/login_provider.dart';
+import 'package:application_new/feature/profile/profile_drawer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -15,6 +16,7 @@ class LoginPage extends ConsumerWidget {
         title: const Text('Login'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
       ),
+      endDrawer: const ProfileDrawer(),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/application/lib/feature/home/home_page.dart
+++ b/application/lib/feature/home/home_page.dart
@@ -1,6 +1,7 @@
 import 'package:application_new/common/loading/async_loading_provider.dart';
 
 import 'package:application_new/feature/authentication/page/login_provider.dart';
+import 'package:application_new/feature/profile/profile_drawer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -16,6 +17,7 @@ class HomePage extends ConsumerWidget {
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         actions: const [],
       ),
+      endDrawer: const ProfileDrawer(),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 36.0),
         child: Column(

--- a/application/lib/feature/profile/profile_avatar.dart
+++ b/application/lib/feature/profile/profile_avatar.dart
@@ -1,0 +1,25 @@
+import 'package:application_new/common/session/session_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ProfileAvatar extends ConsumerWidget {
+
+  final double? radius;
+
+  const ProfileAvatar({super.key, this.radius = 32.0});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final avatar = ref.watch(sessionProvider).member?.avatar;
+    final ThemeData(:colorScheme) = Theme.of(context);
+
+    return CircleAvatar(
+      radius: radius,
+      backgroundColor: colorScheme.primaryContainer,
+      backgroundImage: avatar != null
+          ? NetworkImage(
+          '${avatar.host}/${avatar.path}.${avatar.ext}')
+          : null,
+    );
+  }
+}

--- a/application/lib/feature/profile/profile_drawer.dart
+++ b/application/lib/feature/profile/profile_drawer.dart
@@ -1,0 +1,88 @@
+import 'package:application_new/common/session/session_provider.dart';
+import 'package:application_new/common/translation/translation_service.dart';
+import 'package:application_new/domain/member/member_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ProfileDrawer extends ConsumerWidget {
+  const ProfileDrawer({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final member = ref.watch(sessionProvider).member;
+
+    final tr = ref.watch(translationServiceProvider);
+
+    final ThemeData(:colorScheme) = Theme.of(context);
+
+    final avatar = member?.avatar;
+    const tilePadding = EdgeInsets.symmetric(vertical: 4.0, horizontal: 16.0);
+
+    return Drawer(
+      child: SafeArea(
+        child: ListView(
+            padding: EdgeInsets.zero,
+            physics: const ClampingScrollPhysics(),
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                    child: IconButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        icon: const Icon(Icons.close)),
+                  ),
+                  Wrap(
+                    children: [
+                      IconButton(
+                          onPressed: () {},
+                          icon: const Icon(Icons.notifications_none_outlined)),
+                      IconButton(
+                          onPressed: () {},
+                          icon: const Icon(Icons.settings_outlined)),
+                      const SizedBox(width: 8.0),
+                    ],
+                  )
+                ],
+              ),
+              ListTile(
+                leading: CircleAvatar(
+                  radius: 32.0,
+                  backgroundColor: colorScheme.primaryContainer,
+                  backgroundImage: avatar != null
+                      ? NetworkImage(
+                          '${avatar.host}/${avatar.path}.${avatar.ext}')
+                      : null,
+                ),
+                title: Text(
+                  member?.nickname ?? tr.from('please_log_in'),
+                  style: const TextStyle(
+                    fontSize: 18.0,
+                    fontWeight: FontWeight.w600,
+                    height: 1.0,
+                  ),
+                ),
+                subtitle: member != null
+                    ? Text(
+                        '#${member?.uuid.substring(0, 8)}',
+                        style: const TextStyle(fontSize: 14.0),
+                      )
+                    : null,
+              ),
+              const SizedBox(height: 8.0),
+              ListTile(
+                onTap: member != null ? () {} : null,
+                contentPadding: tilePadding,
+                title: Text(
+                  tr.from('edit_profile'),
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                trailing: const Icon(Icons.keyboard_arrow_right_outlined),
+              ),
+              Container(height: 8.0, color: colorScheme.surfaceContainerHigh),
+            ]),
+      ),
+    );
+  }
+}

--- a/application/lib/feature/profile/profile_drawer.dart
+++ b/application/lib/feature/profile/profile_drawer.dart
@@ -1,8 +1,11 @@
+import 'package:application_new/common/router/router_provider.dart';
 import 'package:application_new/common/session/session_provider.dart';
 import 'package:application_new/common/translation/translation_service.dart';
 import 'package:application_new/domain/member/member_model.dart';
+import 'package:application_new/feature/profile/profile_avatar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 class ProfileDrawer extends ConsumerWidget {
   const ProfileDrawer({super.key});
@@ -12,10 +15,8 @@ class ProfileDrawer extends ConsumerWidget {
     final member = ref.watch(sessionProvider).member;
 
     final tr = ref.watch(translationServiceProvider);
-
     final ThemeData(:colorScheme) = Theme.of(context);
 
-    final avatar = member?.avatar;
     const tilePadding = EdgeInsets.symmetric(vertical: 4.0, horizontal: 16.0);
 
     return Drawer(
@@ -47,14 +48,7 @@ class ProfileDrawer extends ConsumerWidget {
                 ],
               ),
               ListTile(
-                leading: CircleAvatar(
-                  radius: 32.0,
-                  backgroundColor: colorScheme.primaryContainer,
-                  backgroundImage: avatar != null
-                      ? NetworkImage(
-                          '${avatar.host}/${avatar.path}.${avatar.ext}')
-                      : null,
-                ),
+                leading: const ProfileAvatar(),
                 title: Text(
                   member?.nickname ?? tr.from('please_log_in'),
                   style: const TextStyle(
@@ -71,16 +65,18 @@ class ProfileDrawer extends ConsumerWidget {
                     : null,
               ),
               const SizedBox(height: 8.0),
-              ListTile(
-                onTap: member != null ? () {} : null,
-                contentPadding: tilePadding,
-                title: Text(
-                  tr.from('edit_profile'),
-                  style: const TextStyle(fontWeight: FontWeight.bold),
+              if (member != null) ...[
+                ListTile(
+                  onTap: () => context.push('/profile/edit'),
+                  contentPadding: tilePadding,
+                  title: Text(
+                    tr.from('edit_profile'),
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  trailing: const Icon(Icons.keyboard_arrow_right_outlined),
                 ),
-                trailing: const Icon(Icons.keyboard_arrow_right_outlined),
-              ),
-              Container(height: 8.0, color: colorScheme.surfaceContainerHigh),
+                Container(height: 8.0, color: colorScheme.surfaceContainerHigh),
+              ]
             ]),
       ),
     );

--- a/application/lib/feature/profile/profile_edit_page.dart
+++ b/application/lib/feature/profile/profile_edit_page.dart
@@ -1,0 +1,101 @@
+import 'package:application_new/common/session/session_provider.dart';
+import 'package:application_new/common/translation/translation_service.dart';
+import 'package:application_new/feature/profile/profile_avatar.dart';
+import 'package:application_new/feature/profile/profile_edit_provider.dart';
+import 'package:application_new/feature/profile/profile_edit_state.dart';
+import 'package:application_new/shared/model/member_model.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class ProfileEditPage extends ConsumerWidget {
+  ProfileEditPage({super.key});
+
+  final formKey = GlobalKey<FormState>();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ProfileEditState(
+      :nickname,
+      ageGroup: memberAgeGroup,
+      gender: memberGender
+    ) = ref.watch(profileEditProvider);
+
+    final tr = ref.watch(translationServiceProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(tr.from('edit_profile')),
+      ),
+      body: Form(
+        key: formKey,
+        child: ListView(
+          physics: const ClampingScrollPhysics(),
+          padding: const EdgeInsets.symmetric(vertical: 48.0, horizontal: 24.0),
+          children: [
+            const Center(child: ProfileAvatar(radius: 56.0)),
+            const SizedBox(height: 24.0),
+            TextFormField(
+              decoration: InputDecoration(labelText: tr.from('nickname')),
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return tr.from('please_enter_nickname');
+                }
+                return null;
+              },
+              onChanged: (value) {
+                final isValid = formKey.currentState?.validate();
+                if (isValid == null || isValid == false) return;
+                ref.read(profileEditProvider.notifier).editNickname(value);
+              },
+              initialValue: nickname,
+            ),
+            const SizedBox(height: 48.0),
+            Text(tr.from('gender')),
+            const SizedBox(height: 12.0),
+            Wrap(
+              spacing: 12.0,
+              children: [
+                for (final gender in Gender.values)
+                  ChoiceChip(
+                      visualDensity: VisualDensity.standard,
+                      label: Text(tr.fromEnum(gender)),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 16.0, vertical: 12.0),
+                      onSelected: (_) => ref
+                          .read(profileEditProvider.notifier)
+                          .selectGender(gender),
+                      selected: memberGender == gender),
+              ],
+            ),
+            const SizedBox(height: 48.0),
+            Text(tr.from('age_group')),
+            const SizedBox(height: 8.0),
+            Wrap(
+              spacing: 8.0,
+              children: [
+                for (final ageGroup in AgeGroup.values)
+                  ChoiceChip(
+                      label: Text(tr.fromEnum(ageGroup)),
+                      onSelected: (_) => ref
+                          .read(profileEditProvider.notifier)
+                          .selectAgeGroup(ageGroup),
+                      selected: memberAgeGroup == ageGroup)
+              ],
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: SafeArea(
+          child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24.0),
+              child: FilledButton(
+                  onPressed: () {
+                    final isValid = formKey.currentState?.validate();
+                    if (isValid == null || isValid == false) return;
+                    ref.read(profileEditProvider.notifier).submit();
+                  },
+                  child: Text(tr.from('edit_complete'))))),
+    );
+  }
+}

--- a/application/lib/feature/profile/profile_edit_page.dart
+++ b/application/lib/feature/profile/profile_edit_page.dart
@@ -85,21 +85,20 @@ class ProfileEditPage extends ConsumerWidget {
           child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 24.0),
               child: FilledButton(
-                  onPressed: errorMessages.isEmpty
-                      ? () {
-                          final notifier =
-                              ref.read(profileEditProvider.notifier);
-
-                          notifier.submit().catchError((error) {
-                            if (error is ServerFailException) {
-                              notifier.updateErrorMessages(error.data);
-                              return;
-                            }
-                            throw error;
-                          });
-                        }
-                      : null,
+                  onPressed: errorMessages.isEmpty ? () => _submit(ref) : null,
                   child: Text(tr.from('edit_complete'))))),
     );
+  }
+
+  void _submit(WidgetRef ref) {
+    final notifier = ref.read(profileEditProvider.notifier);
+
+    notifier.submit().catchError((error) {
+      if (error is ServerFailException) {
+        notifier.updateErrorMessages(error.data);
+        return;
+      }
+      throw error;
+    });
   }
 }

--- a/application/lib/feature/profile/profile_edit_provider.dart
+++ b/application/lib/feature/profile/profile_edit_provider.dart
@@ -2,6 +2,7 @@ import 'package:application_new/common/exception/exception.dart';
 import 'package:application_new/common/http/http_service_provider.dart';
 import 'package:application_new/common/loading/async_loading_provider.dart';
 import 'package:application_new/common/session/session_provider.dart';
+import 'package:application_new/common/translation/translation_service.dart';
 import 'package:application_new/domain/member/member_model.dart';
 import 'package:application_new/feature/authentication/model/auth_model.dart';
 import 'package:application_new/feature/authentication/service/auth_service_provider.dart';
@@ -32,9 +33,24 @@ class ProfileEdit extends _$ProfileEdit {
     );
   }
 
-  void editNickname(String editNickname) {
+  void editNickname(String? editNickname) {
     if (state.nickname == editNickname) return;
-    state = state.copyWith(nickname: editNickname);
+    final errorMessages = Map.of(state.errorMessages);
+
+    if (editNickname == null || editNickname.isEmpty) {
+      errorMessages['nickname'] =
+          ref.read(translationServiceProvider).from('please_enter_nickname');
+
+      state = state.copyWith(errorMessages: errorMessages);
+      return;
+    }
+
+    errorMessages.remove('nickname');
+
+    state = state.copyWith(
+      errorMessages: errorMessages,
+      nickname: editNickname,
+    );
   }
 
   void selectGender(Gender gender) {
@@ -47,7 +63,7 @@ class ProfileEdit extends _$ProfileEdit {
     state = state.copyWith(ageGroup: ageGroup);
   }
 
-  void submit() async {
+  Future<void> submit() async {
     final loadingNotifier = ref.read(asyncLoadingProvider.notifier);
 
     final updatedMember = await loadingNotifier.guard(() async {
@@ -77,7 +93,11 @@ class ProfileEdit extends _$ProfileEdit {
 
       return MemberModel.fromJson(response['member']);
     });
-    
+
     ref.read(sessionProvider.notifier).updateLoginMember(updatedMember);
+  }
+
+  void updateErrorMessages(Map<String, String> errorMessages) {
+    state = state.copyWith(errorMessages: errorMessages);
   }
 }

--- a/application/lib/feature/profile/profile_edit_provider.dart
+++ b/application/lib/feature/profile/profile_edit_provider.dart
@@ -1,3 +1,4 @@
+import 'package:application_new/common/event/event.dart';
 import 'package:application_new/common/exception/exception.dart';
 import 'package:application_new/common/http/http_service_provider.dart';
 import 'package:application_new/common/loading/async_loading_provider.dart';
@@ -93,8 +94,10 @@ class ProfileEdit extends _$ProfileEdit {
 
       return MemberModel.fromJson(response['member']);
     });
-
+    eventController.add(MessageEvent(
+        ref.read(translationServiceProvider).from('profile_has_been_edited')));
     ref.read(sessionProvider.notifier).updateLoginMember(updatedMember);
+
   }
 
   void updateErrorMessages(Map<String, String> errorMessages) {

--- a/application/lib/feature/profile/profile_edit_provider.dart
+++ b/application/lib/feature/profile/profile_edit_provider.dart
@@ -1,0 +1,83 @@
+import 'package:application_new/common/exception/exception.dart';
+import 'package:application_new/common/http/http_service_provider.dart';
+import 'package:application_new/common/loading/async_loading_provider.dart';
+import 'package:application_new/common/session/session_provider.dart';
+import 'package:application_new/domain/member/member_model.dart';
+import 'package:application_new/feature/authentication/model/auth_model.dart';
+import 'package:application_new/feature/authentication/service/auth_service_provider.dart';
+import 'package:application_new/feature/profile/profile_edit_state.dart';
+import 'package:application_new/shared/model/member_model.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'profile_edit_provider.g.dart';
+
+@riverpod
+class ProfileEdit extends _$ProfileEdit {
+  late MemberModel member;
+
+  @override
+  ProfileEditState build() {
+    final member = ref.watch(sessionProvider).member;
+
+    if (member == null) {
+      throw AuthorizationException();
+    }
+
+    this.member = member;
+
+    return ProfileEditState(
+      nickname: member.nickname,
+      ageGroup: member.ageGroup,
+      gender: member.gender,
+    );
+  }
+
+  void editNickname(String editNickname) {
+    if (state.nickname == editNickname) return;
+    state = state.copyWith(nickname: editNickname);
+  }
+
+  void selectGender(Gender gender) {
+    if (state.gender == gender) return;
+    state = state.copyWith(gender: gender);
+  }
+
+  void selectAgeGroup(AgeGroup ageGroup) {
+    if (state.ageGroup == ageGroup) return;
+    state = state.copyWith(ageGroup: ageGroup);
+  }
+
+  void submit() async {
+    final loadingNotifier = ref.read(asyncLoadingProvider.notifier);
+
+    final updatedMember = await loadingNotifier.guard(() async {
+      final AuthModel(:accessToken) =
+          await ref.read(authServiceProvider).find();
+
+      final Map<String, String> data = {};
+
+      if (member.nickname != state.nickname) {
+        data['nickname'] = state.nickname;
+      }
+
+      if (state.ageGroup != null) {
+        data['ageGroup'] = state.ageGroup!.name;
+      }
+
+      if (state.gender != null) {
+        data['gender'] = state.gender!.name;
+      }
+
+      final response = await ref.read(httpServiceProvider).request(
+            'PATCH',
+            '/api/v2/members/me/profile',
+            authorization: accessToken,
+            data: data,
+          );
+
+      return MemberModel.fromJson(response['member']);
+    });
+    
+    ref.read(sessionProvider.notifier).updateLoginMember(updatedMember);
+  }
+}

--- a/application/lib/feature/profile/profile_edit_provider.g.dart
+++ b/application/lib/feature/profile/profile_edit_provider.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'profile_edit_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$profileEditHash() => r'32beae44d20e53f033782e99335eedddccbb48aa';
+
+/// See also [ProfileEdit].
+@ProviderFor(ProfileEdit)
+final profileEditProvider =
+    AutoDisposeNotifierProvider<ProfileEdit, ProfileEditState>.internal(
+  ProfileEdit.new,
+  name: r'profileEditProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$profileEditHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$ProfileEdit = AutoDisposeNotifier<ProfileEditState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/application/lib/feature/profile/profile_edit_provider.g.dart
+++ b/application/lib/feature/profile/profile_edit_provider.g.dart
@@ -6,7 +6,7 @@ part of 'profile_edit_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$profileEditHash() => r'1bf585efc0607920aa232139ec7f236323f61d04';
+String _$profileEditHash() => r'9f6bb3852d5ddfc3db2542e6b0caeef77a33bb44';
 
 /// See also [ProfileEdit].
 @ProviderFor(ProfileEdit)

--- a/application/lib/feature/profile/profile_edit_provider.g.dart
+++ b/application/lib/feature/profile/profile_edit_provider.g.dart
@@ -6,7 +6,7 @@ part of 'profile_edit_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$profileEditHash() => r'32beae44d20e53f033782e99335eedddccbb48aa';
+String _$profileEditHash() => r'1bf585efc0607920aa232139ec7f236323f61d04';
 
 /// See also [ProfileEdit].
 @ProviderFor(ProfileEdit)

--- a/application/lib/feature/profile/profile_edit_state.dart
+++ b/application/lib/feature/profile/profile_edit_state.dart
@@ -1,0 +1,15 @@
+import 'package:application_new/shared/model/member_model.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'profile_edit_state.freezed.dart';
+
+@freezed
+class ProfileEditState with _$ProfileEditState {
+
+  const factory ProfileEditState({
+    required String nickname,
+    Gender? gender,
+    AgeGroup? ageGroup,
+  }) = _ProfileEditState;
+
+}

--- a/application/lib/feature/profile/profile_edit_state.dart
+++ b/application/lib/feature/profile/profile_edit_state.dart
@@ -8,6 +8,7 @@ class ProfileEditState with _$ProfileEditState {
 
   const factory ProfileEditState({
     required String nickname,
+    @Default({}) Map<String, String?> errorMessages,
     Gender? gender,
     AgeGroup? ageGroup,
   }) = _ProfileEditState;

--- a/application/lib/feature/profile/profile_edit_state.freezed.dart
+++ b/application/lib/feature/profile/profile_edit_state.freezed.dart
@@ -17,6 +17,7 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$ProfileEditState {
   String get nickname => throw _privateConstructorUsedError;
+  Map<String, String?> get errorMessages => throw _privateConstructorUsedError;
   Gender? get gender => throw _privateConstructorUsedError;
   AgeGroup? get ageGroup => throw _privateConstructorUsedError;
 
@@ -33,7 +34,11 @@ abstract class $ProfileEditStateCopyWith<$Res> {
           ProfileEditState value, $Res Function(ProfileEditState) then) =
       _$ProfileEditStateCopyWithImpl<$Res, ProfileEditState>;
   @useResult
-  $Res call({String nickname, Gender? gender, AgeGroup? ageGroup});
+  $Res call(
+      {String nickname,
+      Map<String, String?> errorMessages,
+      Gender? gender,
+      AgeGroup? ageGroup});
 }
 
 /// @nodoc
@@ -52,6 +57,7 @@ class _$ProfileEditStateCopyWithImpl<$Res, $Val extends ProfileEditState>
   @override
   $Res call({
     Object? nickname = null,
+    Object? errorMessages = null,
     Object? gender = freezed,
     Object? ageGroup = freezed,
   }) {
@@ -60,6 +66,10 @@ class _$ProfileEditStateCopyWithImpl<$Res, $Val extends ProfileEditState>
           ? _value.nickname
           : nickname // ignore: cast_nullable_to_non_nullable
               as String,
+      errorMessages: null == errorMessages
+          ? _value.errorMessages
+          : errorMessages // ignore: cast_nullable_to_non_nullable
+              as Map<String, String?>,
       gender: freezed == gender
           ? _value.gender
           : gender // ignore: cast_nullable_to_non_nullable
@@ -80,7 +90,11 @@ abstract class _$$ProfileEditStateImplCopyWith<$Res>
       __$$ProfileEditStateImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String nickname, Gender? gender, AgeGroup? ageGroup});
+  $Res call(
+      {String nickname,
+      Map<String, String?> errorMessages,
+      Gender? gender,
+      AgeGroup? ageGroup});
 }
 
 /// @nodoc
@@ -97,6 +111,7 @@ class __$$ProfileEditStateImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? nickname = null,
+    Object? errorMessages = null,
     Object? gender = freezed,
     Object? ageGroup = freezed,
   }) {
@@ -105,6 +120,10 @@ class __$$ProfileEditStateImplCopyWithImpl<$Res>
           ? _value.nickname
           : nickname // ignore: cast_nullable_to_non_nullable
               as String,
+      errorMessages: null == errorMessages
+          ? _value._errorMessages
+          : errorMessages // ignore: cast_nullable_to_non_nullable
+              as Map<String, String?>,
       gender: freezed == gender
           ? _value.gender
           : gender // ignore: cast_nullable_to_non_nullable
@@ -121,10 +140,23 @@ class __$$ProfileEditStateImplCopyWithImpl<$Res>
 
 class _$ProfileEditStateImpl implements _ProfileEditState {
   const _$ProfileEditStateImpl(
-      {required this.nickname, this.gender, this.ageGroup});
+      {required this.nickname,
+      final Map<String, String?> errorMessages = const {},
+      this.gender,
+      this.ageGroup})
+      : _errorMessages = errorMessages;
 
   @override
   final String nickname;
+  final Map<String, String?> _errorMessages;
+  @override
+  @JsonKey()
+  Map<String, String?> get errorMessages {
+    if (_errorMessages is EqualUnmodifiableMapView) return _errorMessages;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_errorMessages);
+  }
+
   @override
   final Gender? gender;
   @override
@@ -132,7 +164,7 @@ class _$ProfileEditStateImpl implements _ProfileEditState {
 
   @override
   String toString() {
-    return 'ProfileEditState(nickname: $nickname, gender: $gender, ageGroup: $ageGroup)';
+    return 'ProfileEditState(nickname: $nickname, errorMessages: $errorMessages, gender: $gender, ageGroup: $ageGroup)';
   }
 
   @override
@@ -142,13 +174,16 @@ class _$ProfileEditStateImpl implements _ProfileEditState {
             other is _$ProfileEditStateImpl &&
             (identical(other.nickname, nickname) ||
                 other.nickname == nickname) &&
+            const DeepCollectionEquality()
+                .equals(other._errorMessages, _errorMessages) &&
             (identical(other.gender, gender) || other.gender == gender) &&
             (identical(other.ageGroup, ageGroup) ||
                 other.ageGroup == ageGroup));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, nickname, gender, ageGroup);
+  int get hashCode => Object.hash(runtimeType, nickname,
+      const DeepCollectionEquality().hash(_errorMessages), gender, ageGroup);
 
   /// Create a copy of ProfileEditState
   /// with the given fields replaced by the non-null parameter values.
@@ -163,11 +198,14 @@ class _$ProfileEditStateImpl implements _ProfileEditState {
 abstract class _ProfileEditState implements ProfileEditState {
   const factory _ProfileEditState(
       {required final String nickname,
+      final Map<String, String?> errorMessages,
       final Gender? gender,
       final AgeGroup? ageGroup}) = _$ProfileEditStateImpl;
 
   @override
   String get nickname;
+  @override
+  Map<String, String?> get errorMessages;
   @override
   Gender? get gender;
   @override

--- a/application/lib/feature/profile/profile_edit_state.freezed.dart
+++ b/application/lib/feature/profile/profile_edit_state.freezed.dart
@@ -1,0 +1,182 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'profile_edit_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ProfileEditState {
+  String get nickname => throw _privateConstructorUsedError;
+  Gender? get gender => throw _privateConstructorUsedError;
+  AgeGroup? get ageGroup => throw _privateConstructorUsedError;
+
+  /// Create a copy of ProfileEditState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ProfileEditStateCopyWith<ProfileEditState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ProfileEditStateCopyWith<$Res> {
+  factory $ProfileEditStateCopyWith(
+          ProfileEditState value, $Res Function(ProfileEditState) then) =
+      _$ProfileEditStateCopyWithImpl<$Res, ProfileEditState>;
+  @useResult
+  $Res call({String nickname, Gender? gender, AgeGroup? ageGroup});
+}
+
+/// @nodoc
+class _$ProfileEditStateCopyWithImpl<$Res, $Val extends ProfileEditState>
+    implements $ProfileEditStateCopyWith<$Res> {
+  _$ProfileEditStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ProfileEditState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? nickname = null,
+    Object? gender = freezed,
+    Object? ageGroup = freezed,
+  }) {
+    return _then(_value.copyWith(
+      nickname: null == nickname
+          ? _value.nickname
+          : nickname // ignore: cast_nullable_to_non_nullable
+              as String,
+      gender: freezed == gender
+          ? _value.gender
+          : gender // ignore: cast_nullable_to_non_nullable
+              as Gender?,
+      ageGroup: freezed == ageGroup
+          ? _value.ageGroup
+          : ageGroup // ignore: cast_nullable_to_non_nullable
+              as AgeGroup?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ProfileEditStateImplCopyWith<$Res>
+    implements $ProfileEditStateCopyWith<$Res> {
+  factory _$$ProfileEditStateImplCopyWith(_$ProfileEditStateImpl value,
+          $Res Function(_$ProfileEditStateImpl) then) =
+      __$$ProfileEditStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String nickname, Gender? gender, AgeGroup? ageGroup});
+}
+
+/// @nodoc
+class __$$ProfileEditStateImplCopyWithImpl<$Res>
+    extends _$ProfileEditStateCopyWithImpl<$Res, _$ProfileEditStateImpl>
+    implements _$$ProfileEditStateImplCopyWith<$Res> {
+  __$$ProfileEditStateImplCopyWithImpl(_$ProfileEditStateImpl _value,
+      $Res Function(_$ProfileEditStateImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ProfileEditState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? nickname = null,
+    Object? gender = freezed,
+    Object? ageGroup = freezed,
+  }) {
+    return _then(_$ProfileEditStateImpl(
+      nickname: null == nickname
+          ? _value.nickname
+          : nickname // ignore: cast_nullable_to_non_nullable
+              as String,
+      gender: freezed == gender
+          ? _value.gender
+          : gender // ignore: cast_nullable_to_non_nullable
+              as Gender?,
+      ageGroup: freezed == ageGroup
+          ? _value.ageGroup
+          : ageGroup // ignore: cast_nullable_to_non_nullable
+              as AgeGroup?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ProfileEditStateImpl implements _ProfileEditState {
+  const _$ProfileEditStateImpl(
+      {required this.nickname, this.gender, this.ageGroup});
+
+  @override
+  final String nickname;
+  @override
+  final Gender? gender;
+  @override
+  final AgeGroup? ageGroup;
+
+  @override
+  String toString() {
+    return 'ProfileEditState(nickname: $nickname, gender: $gender, ageGroup: $ageGroup)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ProfileEditStateImpl &&
+            (identical(other.nickname, nickname) ||
+                other.nickname == nickname) &&
+            (identical(other.gender, gender) || other.gender == gender) &&
+            (identical(other.ageGroup, ageGroup) ||
+                other.ageGroup == ageGroup));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, nickname, gender, ageGroup);
+
+  /// Create a copy of ProfileEditState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ProfileEditStateImplCopyWith<_$ProfileEditStateImpl> get copyWith =>
+      __$$ProfileEditStateImplCopyWithImpl<_$ProfileEditStateImpl>(
+          this, _$identity);
+}
+
+abstract class _ProfileEditState implements ProfileEditState {
+  const factory _ProfileEditState(
+      {required final String nickname,
+      final Gender? gender,
+      final AgeGroup? ageGroup}) = _$ProfileEditStateImpl;
+
+  @override
+  String get nickname;
+  @override
+  Gender? get gender;
+  @override
+  AgeGroup? get ageGroup;
+
+  /// Create a copy of ProfileEditState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ProfileEditStateImplCopyWith<_$ProfileEditStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/application/lib/main.dart
+++ b/application/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:application_new/shared/theme/my_chip_theme.dart';
 import 'package:application_new/shared/theme/my_app_bar_theme.dart';
 import 'package:application_new/shared/theme/my_button_theme.dart';
 import 'package:application_new/shared/theme/my_fab_theme.dart';
+import 'package:application_new/shared/theme/my_input_theme.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:easy_localization_loader/easy_localization_loader.dart';
 import 'package:flutter/material.dart';
@@ -66,6 +67,8 @@ void main() async {
           final sessionNotifier =
               providerContainer.read(sessionProvider.notifier);
           sessionNotifier.updateLoginMember(null);
+        case ValidationException():
+          // TODO: Handle this case.
       }
     }
 
@@ -158,18 +161,20 @@ class _MyAppState extends ConsumerState<MyApp> {
         return MyFabTheme(
           child: MyAppBarTheme(
             child: MyButtonTheme(
-              child: MyChipTheme(
-                key: themeKey,
-                child: Stack(
-                  children: [
-                    widget!,
-                    if (isLoading)
-                      Positioned.fill(
-                          child: Container(
-                        color: Colors.white.withOpacity(0.5),
-                        child: const Center(child: CircularProgressIndicator()),
-                      ))
-                  ],
+              child: MyInputTheme(
+                child: MyChipTheme(
+                  key: themeKey,
+                  child: Stack(
+                    children: [
+                      widget!,
+                      if (isLoading)
+                        Positioned.fill(
+                            child: Container(
+                          color: Colors.white.withOpacity(0.5),
+                          child: const Center(child: CircularProgressIndicator()),
+                        ))
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/application/lib/shared/theme/my_button_theme.dart
+++ b/application/lib/shared/theme/my_button_theme.dart
@@ -23,15 +23,13 @@ class MyButtonTheme extends StatelessWidget {
                 textStyle: textTheme.bodyLarge
                     ?.copyWith(fontWeight: FontWeight.w600))),
         filledButtonTheme: FilledButtonThemeData(
-            style: FilledButton.styleFrom(
-          shape:
-              RoundedRectangleBorder(
-                  side: BorderSide(color: colorScheme.primaryFixedDim),
-                  borderRadius: BorderRadius.circular(8.0)),
-          textStyle: buttonTextStyle,
-          backgroundColor: colorScheme.primaryContainer,
-          foregroundColor: colorScheme.primary,
-        )),
+          style: FilledButton.styleFrom(
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8.0)),
+            textStyle: buttonTextStyle,
+            padding: EdgeInsets.symmetric(vertical: 12.0, horizontal: 16)
+          ),
+        ),
         outlinedButtonTheme: OutlinedButtonThemeData(
           style: OutlinedButton.styleFrom(
             side: BorderSide(color: colorScheme.surfaceDim),

--- a/application/lib/shared/theme/my_chip_theme.dart
+++ b/application/lib/shared/theme/my_chip_theme.dart
@@ -30,14 +30,14 @@ class MyChipTheme extends StatelessWidget {
               backgroundColor: colorScheme.surfaceContainerLow,
               deleteIconColor: colorScheme.primary,
               shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16.0)),
+                  borderRadius: BorderRadius.circular(8.0)),
               side: WidgetStateBorderSide.resolveWith((states) {
                 if (states.contains(WidgetState.selected)) {
                   return BorderSide(color: colorScheme.primaryFixedDim);
                 }
                 return BorderSide(color: colorScheme.surfaceDim);
               }),
-              padding: const EdgeInsets.all(10.0)),
+              padding: const EdgeInsets.all(8.0)),
         ),
         child: _child);
   }

--- a/application/lib/shared/theme/my_input_theme.dart
+++ b/application/lib/shared/theme/my_input_theme.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class MyInputTheme extends StatelessWidget {
+  final Widget child;
+
+  const MyInputTheme({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Theme(
+        data: Theme.of(context).copyWith(
+            inputDecorationTheme: InputDecorationTheme(
+                labelStyle: TextStyle(
+                    color: colorScheme.onSurfaceVariant,
+                    fontSize: 15.0,
+                    fontWeight: FontWeight.bold))),
+        child: child);
+  }
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/controller/MemberController.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/controller/MemberController.java
@@ -1,16 +1,17 @@
 package com.yeohaeng_ttukttak.server.application.member.controller;
 
-import com.yeohaeng_ttukttak.server.application.member.controller.dto.FindMemberResponse;
+import com.yeohaeng_ttukttak.server.application.member.controller.dto.MemberResponse;
+import com.yeohaeng_ttukttak.server.application.member.controller.dto.UpdateMemberProfileRequest;
 import com.yeohaeng_ttukttak.server.application.member.service.FindMemberService;
+import com.yeohaeng_ttukttak.server.application.member.service.UpdateMemberService;
 import com.yeohaeng_ttukttak.server.common.aop.annotation.Authorization;
 import com.yeohaeng_ttukttak.server.common.dto.ServerResponse;
 import com.yeohaeng_ttukttak.server.domain.auth.dto.AuthorizationDto;
 import com.yeohaeng_ttukttak.server.domain.member.dto.MemberDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Objects;
 
 @RestController
 @RequestMapping("/api/v2/members")
@@ -18,18 +19,33 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final FindMemberService findMemberService;
+    private final UpdateMemberService updateMemberService;
 
     @GetMapping("/{id}")
-    public ServerResponse<FindMemberResponse> find(@PathVariable String id) {
+    public ServerResponse<MemberResponse> find(@PathVariable String id) {
         final MemberDto dto = findMemberService.findOne(id);
-        return new ServerResponse<>(new FindMemberResponse(dto));
+        return new ServerResponse<>(new MemberResponse(dto));
     }
 
     @GetMapping("/me")
     @Authorization
-    public ServerResponse<FindMemberResponse> findMe(AuthorizationDto authorization) {
+    public ServerResponse<MemberResponse> findMe(AuthorizationDto authorization) {
         final MemberDto dto = findMemberService.findOne(authorization.memberId());
-        return new ServerResponse<>(new FindMemberResponse(dto));
+        return new ServerResponse<>(new MemberResponse(dto));
+    }
+
+    @PatchMapping("/me/profile")
+    @Authorization
+    public ServerResponse<MemberResponse> updateProfile(
+            @RequestBody UpdateMemberProfileRequest request,
+            AuthorizationDto authorization) {
+
+        updateMemberService.updateProfile(authorization.memberId(),
+                request.nickname(), request.ageGroup(), request.gender());
+
+        MemberDto dto = findMemberService.findOne(authorization.memberId());
+        return new ServerResponse<>(new MemberResponse(dto));
+
     }
 
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/controller/dto/MemberResponse.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/controller/dto/MemberResponse.java
@@ -2,4 +2,4 @@ package com.yeohaeng_ttukttak.server.application.member.controller.dto;
 
 import com.yeohaeng_ttukttak.server.domain.member.dto.MemberDto;
 
-public record FindMemberResponse(MemberDto member) { }
+public record MemberResponse(MemberDto member) { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/controller/dto/UpdateMemberProfileRequest.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/controller/dto/UpdateMemberProfileRequest.java
@@ -1,0 +1,10 @@
+package com.yeohaeng_ttukttak.server.application.member.controller.dto;
+
+import com.yeohaeng_ttukttak.server.domain.member.entity.AgeGroup;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Gender;
+
+public record UpdateMemberProfileRequest(
+        String nickname,
+        AgeGroup ageGroup,
+        Gender gender
+) { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/service/FindMemberService.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/service/FindMemberService.java
@@ -4,6 +4,7 @@ import com.yeohaeng_ttukttak.server.domain.member.dto.MemberDto;
 import com.yeohaeng_ttukttak.server.domain.member.entity.Member;
 import com.yeohaeng_ttukttak.server.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,10 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class FindMemberService {
 
     private final MemberService memberService;
+    private final Environment environment;
 
     public MemberDto findOne(String memberId) {
         final Member member = memberService.find(memberId);
-        return MemberDto.of(member);
+        return MemberDto.of(environment.getProperty("AVATAR_HOST"), member);
     }
 
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/service/UpdateMemberService.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/member/service/UpdateMemberService.java
@@ -1,0 +1,37 @@
+package com.yeohaeng_ttukttak.server.application.member.service;
+
+import com.yeohaeng_ttukttak.server.domain.member.entity.AgeGroup;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Gender;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Member;
+import com.yeohaeng_ttukttak.server.domain.member.service.MemberService;
+import com.yeohaeng_ttukttak.server.domain.nickname.Nickname;
+import com.yeohaeng_ttukttak.server.domain.nickname.NicknameService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UpdateMemberService {
+
+    private final MemberService memberService;
+    private final NicknameService nicknameService;
+
+    @Transactional
+    public void updateProfile(String memberId, String nickname, AgeGroup ageGroup, Gender gender) {
+
+        final Member member = memberService.find(memberId);
+        Nickname updateNickname = null;
+
+        if (Objects.nonNull(nickname)) {
+            updateNickname = nicknameService.create(nickname);
+        }
+
+        member.updateProfile(updateNickname, gender, ageGroup);
+
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/dto/AvatarDto.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/dto/AvatarDto.java
@@ -1,0 +1,15 @@
+package com.yeohaeng_ttukttak.server.domain.member.dto;
+
+import com.yeohaeng_ttukttak.server.domain.member.entity.Avatar;
+
+public record AvatarDto(
+        String host,
+        String path,
+        String ext
+) { 
+    
+    public static AvatarDto of(String host, Avatar avatar) {
+        return new AvatarDto(host, avatar.path(), avatar.ext());
+    }
+    
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/dto/MemberDto.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/dto/MemberDto.java
@@ -8,12 +8,17 @@ public record MemberDto(
         String uuid,
         String nickname,
         AgeGroup ageGroup,
-        Gender gender
+        Gender gender,
+        AvatarDto avatar
 ) {
 
-    public static MemberDto of(Member member) {
+    public static MemberDto of(String host, Member member) {
         return new MemberDto(
-                member.uuid(), member.nickname(), member.ageGroup(), member.gender());
+                member.uuid(),
+                member.nickname(),
+                member.ageGroup(),
+                member.gender(),
+                AvatarDto.of(host, member.avatar()));
     }
 
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/AgeGroup.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/AgeGroup.java
@@ -43,4 +43,6 @@ public enum AgeGroup {
         return seventiesPlus;
     }
 
+
+
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/Avatar.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/Avatar.java
@@ -1,0 +1,32 @@
+package com.yeohaeng_ttukttak.server.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn
+public abstract class Avatar {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    abstract public String path();
+
+    abstract public String ext();
+
+    protected Avatar(Member member) {
+        this.member = member;
+    }
+
+    protected Member member() {
+        return member;
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/DefaultAvatar.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/DefaultAvatar.java
@@ -1,0 +1,62 @@
+package com.yeohaeng_ttukttak.server.domain.member.entity;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Objects;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue("D")
+public class DefaultAvatar extends Avatar {
+
+    private static final List<String> ageGroupKeyword = List.of("kid", "young", "middle", "old");
+    private static final List<String> genderKeyword = List.of("male", "female");
+
+    private static final int imagesPerType = 24;
+
+
+    @Override
+    public String path() {
+        int avatarIndex = (int) (member().id() % imagesPerType) + 1;
+
+        return "avatars/%s/%s/%d".formatted(
+                parseGender(member()), parseAgeGroup(member()), avatarIndex);
+    }
+
+    @Override
+    public String ext() {
+        return "png";
+    }
+
+    private String parseAgeGroup(Member member) {
+
+        if (Objects.isNull(member.ageGroup())) {
+            int index = (int)(member.id() % ageGroupKeyword.size());
+            return ageGroupKeyword.get(index);
+        }
+
+        return switch (member.ageGroup()) {
+            case underNine, teens -> ageGroupKeyword.get(0);
+            case twenties, thirties -> ageGroupKeyword.get(1);
+            case forties, fifties -> ageGroupKeyword.get(2);
+            case sixties, seventiesPlus -> ageGroupKeyword.get(3);
+        };
+
+    }
+
+    private String parseGender(Member member) {
+
+        if (Objects.isNull(member.gender())) {
+            int index = (int)(member.id() % genderKeyword.size());
+            return genderKeyword.get(index);
+        }
+
+        return member.gender().name();
+
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/Member.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/Member.java
@@ -67,15 +67,14 @@ public class Member {
     }
 
     /**
-     * 사용자 프로필 내용을 변경한다. 변경할 속성을 null이 아닌 값으로
-     * @param nickname
-     * @param gender
-     * @param ageGroup
+     * 사용자 프로필 내용을 변경한다. 변경할 속성을 null이 아닌 값으로 설정한다.
+     * @param nickname 변경할 닉네임 값
+     * @param gender 변경할 성별 값
+     * @param ageGroup 변경할 연령대 값
      */
-    public void updateProfile(String nickname, Gender gender, AgeGroup ageGroup) {
+    public void updateProfile(Nickname nickname, Gender gender, AgeGroup ageGroup) {
         if (nickname != null) {
-
-            this.nickname = nickname;
+            this.nickname = nickname.value();
         }
 
         if (gender != null) {

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/Member.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/Member.java
@@ -42,6 +42,10 @@ public class Member {
     @JoinColumn(name = "auth_id", updatable = false)
     private OAuth auth;
 
+    @NotNull
+    @OneToOne(mappedBy = "member")
+    private Avatar avatar;
+
     public Member(OAuth auth, Nickname nickname, Gender gender, LocalDate birthDate) {
         this.auth = auth;
         this.uuid = StringUtil.createShortUUID();
@@ -49,6 +53,8 @@ public class Member {
         this.gender = gender;
         this.ageGroup = AgeGroup.fromBrithDate(birthDate);
     }
+
+    Long id() { return id; }
 
     public String uuid() {
         return uuid;
@@ -64,6 +70,10 @@ public class Member {
 
     public String nickname() {
         return nickname;
+    }
+
+    public Avatar avatar() {
+        return avatar;
     }
 
     /**


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> Ex. close #이슈 번호, #이슈 번호
#7 

## 📝 작업 내용
> 작업한 내용을 간략히 설명해 주세요.

### 아바타 서버에서 관리하도록 변경

```mermaid
classDiagram
direction BT
class Avatar {
    Long  id
}
class DefaultAvatar
class UploadAvatar
class Member {
    Long  id
    AgeGroup  ageGroup
    Gender  gender
    String  nickname
    String  uuid
}
class OAuth {
    Long  id
    String  openId
    OAuthProvider  provider
}

DefaultAvatar  --|>  Avatar 
UploadAvatar  --|>  Avatar 
Member "0..1" <--> "0..1" Avatar 
Member "0..1" --> "0..1" OAuth 
```

이미지를 업로드하지 않은 경우, 사용자 프로필 정보에 맞는 기본 아바타를 표시합니다. 원래 애플리케이션에서 했는데, 아래 이유로 서버로 옮겼습니다.
- 사용자 `Sequential ID`를 아바타 해시 계산에 활용할 수 있습니다. 아바타 가짓수를 사용자 식별자에 따라 할당하는데, `uuid`를 따로 해싱하지 않고 계산할 수 있습니다.
- 프로필 이미지를 비즈니스 제약 조건으로 관리할 수 있습니다. 추후 구현이 변경될 때 컴파일 타입으로 예외를 파악할 수 있습니다.

<br/>

### 프로필 UI 구현
<img src="https://github.com/user-attachments/assets/1526c975-fd12-4129-a340-8a4d9a386f31" width="240px" />

애플리케이션 전역에서 사용할 수 있도록 별도 `Profile` 도메인으로 분리하고 `ProfileDrawer` 로 구현했습니다. 이를 `Scaffold`의 `endDrawer`에 지정하면 간단히 오른쪽 서랍 UI를 사용할 수 있습니다.

<br/>

### 프로필 수정 기능 구현
원래 Flutter가 제공하는 Form Validator 기능을 사용하려 했으나, 서버에서 발생한 예외를 필드에 설정하지 못하는 문제가 있습니다. 그래서 프로바이더에서 에러를 상태관리 하도록 변경했습니다.
- 애플리케이션 유효성 로직 및 서버 예외를 한꺼번에 관리할 수 있습니다.
- 서버 예외를 캐치한 뒤, 메세지 그대로 폼 필드에 에러 메세지를 추가할 수 있습니다.
- 예외 메세지가 존재하는 경우, 상태를 추적해 수정 버튼을 실시간으로 비활성화 시킬 수 있습니다.

## ✅ 작업 결과
> 작업 내용 Notion 링크, 혹은 이미지를 첨부해 주세요.
![Simulator Screen Recording - iPhone 15 Pro Max - 2024-12-09 at 17 37 27](https://github.com/user-attachments/assets/0a939565-f61d-40db-bc4c-6b891bbc0276)

<br/>

## 💬 추가 사항 (선택)
> 추가로 기재할 사항이 있으면 기재해 주세요.

### Mac에서 간편하게 파일 이름 바꾸는 법

한꺼번에 여러 파일의 이름을 변경해야 할 때가 있는데, 쉘 스크립트로 자동화할 수 있습니다.

```bash
for file in FY*; do
	mv "$file" "${file#FY}";
done
```
위 스크립트는 파일 이름이 `FY`로 시작하는 파일을 모두 선택합니다. 추후 명령어를 적용할 수 있습니다.

```bash
for i in {1..6}; do 
	cp "$i.png" "$((i + 18)).png";
done
```
이름이 아니라 특정 `i`개 파일을 순차적으로 복사해야 한다면 위 코드를 사용할 수 있습니다.

<br />

### Dart에서 비동기 예외 캐치하기
```dart
void main() {
  handleAuthResponse(const {'username': 'dash', 'age': 3})
      .then((_) => ...)
      .catchError(handleFormatException, test: (e) => e is FormatException)
      .catchError(handleAuthorizationException,
          test: (e) => e is AuthorizationException);
}
```
자바스크립트의 Promise에 대응하는 Future의 예외는 `try-catch`로 처리할 수 없습니다. 예외는 Call Stack을 통해 밖으로 순차적으로 전파되는데, Future 또한 Promise처럼 별도 이벤트 루프에서 실행되기 때문입니다.

이를 처리하려면, `catchError()` 을 사용해야 합니다.

> https://dart.dev/libraries/async/futures-error-handling