### PR TITLE
Improve(#8): 선택한 도시 목록 표시 및 인터렉션 구현

### DIFF
--- a/application/assets/translations/ko.yaml
+++ b/application/assets/translations/ko.yaml
@@ -6,6 +6,7 @@
 '{} comments': 댓글 {}개
 '{} has been added to plan successfully.': '{}이(가) 일정에 추가되었습니다.'
 '{} has been removed from plan successfully.': '{}이(가) 일정에서 제거되었습니다.'
+'{} has been selected.': '{}이(가) 선택되었습니다.'
 
 Add to your plan: 일정에 추가하기
 Age group: 연령대
@@ -81,6 +82,8 @@ You can invite participants by sharing this link.: 초대 링크를 공유해 �
 You can plan the travel with participants.: 일행과 함께 여행 계획을 짤 수 있어요.
 
 Unselect: 선택 해제
+
+View: 보기
 
 enum:
   TravelCompanionType:

--- a/application/assets/translations/ko.yaml
+++ b/application/assets/translations/ko.yaml
@@ -18,6 +18,7 @@ Back to the main page: 메인 페이지로
 
 Cancel: 취소
 Close: 닫기
+Confirm: 확인
 Comment: 댓글
 Comment by {}: '{}님의 댓글'
 Complete: 완료

--- a/application/lib/common/event/event.dart
+++ b/application/lib/common/event/event.dart
@@ -1,13 +1,15 @@
 import 'dart:async';
 import 'dart:ui';
 
+import 'package:application_new/shared/dto/reference.dart';
+
 sealed class Event {}
 
 class MessageEvent extends Event {
   final String message;
-  final VoidCallback? onCancel;
+  final Reference<String, VoidCallback>? onActionRef;
 
-  MessageEvent(this.message, {this.onCancel});
+  MessageEvent(this.message, {this.onActionRef});
 }
 
 final eventController = StreamController<Event>();

--- a/application/lib/feature/geography_select/geography_select_provider.dart
+++ b/application/lib/feature/geography_select/geography_select_provider.dart
@@ -1,3 +1,4 @@
+import 'package:application_new/common/util/riverpod_extensions.dart';
 import 'package:application_new/domain/geo_json/geo_json_repository.dart';
 import 'package:application_new/domain/geography/geography_model.dart';
 import 'package:application_new/domain/geography/geography_provider.dart';
@@ -10,6 +11,8 @@ part 'geography_select_provider.g.dart';
 class GeographySelect extends _$GeographySelect {
   @override
   FutureOr<GeographySelectState> build(int id) async {
+    ref.cacheFor(const Duration(minutes: 30));
+
     final model = await ref.watch(geoJsonRepositoryProvider).findById(id);
     final geographies = await ref.watch(geographiesProvider.future);
 

--- a/application/lib/feature/geography_select/geography_select_provider.g.dart
+++ b/application/lib/feature/geography_select/geography_select_provider.g.dart
@@ -6,7 +6,7 @@ part of 'geography_select_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$geographySelectHash() => r'4a70a2baec9f2843862907c613f7d23e90a536f6';
+String _$geographySelectHash() => r'22730a1170f2d10fd398c07442ad1fdaa626b909';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/application/lib/feature/geography_select/geography_select_view.dart
+++ b/application/lib/feature/geography_select/geography_select_view.dart
@@ -22,6 +22,7 @@ class GeographySelectView extends ConsumerStatefulWidget {
   final FutureOr<void> Function(GeographyModel model) onSelect;
   final VoidCallback? onCancel;
 
+  final GeographyModel? initialActiveChild;
   final Iterable<GeographyModel> selectedChildren;
 
   final bool isUnSelectable;
@@ -31,6 +32,7 @@ class GeographySelectView extends ConsumerStatefulWidget {
       required this.id,
       required this.onSelect,
       required this.selectedChildren,
+        this.initialActiveChild,
       this.onCancel,
       this.isUnSelectable = true});
 
@@ -40,10 +42,13 @@ class GeographySelectView extends ConsumerStatefulWidget {
 
 class _StateSelectViewState extends ConsumerState<GeographySelectView> {
   final Completer<void> onMapReadyCompleter = Completer();
+  final Completer<void> onPageViewReadyCompleter = Completer();
+
   final LayerHitNotifier hitNotifier = ValueNotifier(null);
 
   final MapController mapController = MapController();
-  final PageController pageController = PageController();
+
+  late final PageController pageController;
 
   Iterable<Polygon>? activePolygons;
   Iterable<Polygon>? polygons;
@@ -52,6 +57,11 @@ class _StateSelectViewState extends ConsumerState<GeographySelectView> {
 
   @override
   void initState() {
+    pageController = PageController(onAttach: (position) {
+      if (onPageViewReadyCompleter.isCompleted) return;
+      onPageViewReadyCompleter.complete();
+    });
+
     Future.microtask(() async {
       await onMapReadyCompleter.future;
       hitNotifier.addListener(() async {
@@ -121,7 +131,9 @@ class _StateSelectViewState extends ConsumerState<GeographySelectView> {
         ));
   }
 
-  void movePage(int targetIndex) {
+  void movePage(int targetIndex) async {
+    await onPageViewReadyCompleter.future;
+
     final curtIndex = pageController.page!.toInt();
 
     if (curtIndex == targetIndex) return;
@@ -149,7 +161,9 @@ class _StateSelectViewState extends ConsumerState<GeographySelectView> {
           if (polygons == null) {
             init(model, children);
           }
-          readyActivePolygon(activeChild?.id);
+          final curtActiveChild = activeChild ?? widget.initialActiveChild;
+
+          readyActivePolygon(curtActiveChild?.id);
           readySelectPolygon(widget.selectedChildren.map((child) => child.id));
 
           return Scaffold(
@@ -171,103 +185,93 @@ class _StateSelectViewState extends ConsumerState<GeographySelectView> {
                 final int itemsPerPage = rowCount * columnCount;
                 final int pageCount = (children.length / itemsPerPage).ceil();
 
-                return Consumer(builder: (context, ref, child) {
-                  ref.listen(geographySelectProvider(widget.id), (prev, next) {
-                    final activeId = next.value?.activeChild?.id;
-                    if (prev?.value?.activeChild?.id == activeId) return;
-                    if (activeId == null) return;
 
-                    int index = 0;
+                if (curtActiveChild != null) {
+                  final index = children.indexOf(curtActiveChild);
 
-                    for (int i = 0; i < children.length; i++) {
-                      if (children[i].id != activeId) continue;
-                      index = i;
-                      break;
-                    }
-                    movePage((index / itemsPerPage).floor());
-                  });
+                  movePage((index / itemsPerPage).floor());
+                }
 
-                  return Column(
-                    children: [
-                      SizedBox(
-                        width: constraints.maxWidth,
-                        height: maxHeight - usableHeight,
-                        child: FlutterMap(
-                            mapController: mapController,
-                            options: MapOptions(
-                              interactionOptions: const InteractionOptions(
-                                  flags: InteractiveFlag.none),
-                              backgroundColor: colorScheme.surface,
-                              onMapReady: () {
-                                if (onMapReadyCompleter.isCompleted) return;
-                                onMapReadyCompleter.complete();
-                              },
-                            ),
-                            children: [
-                              PolygonLayer(
-                                  hitNotifier: hitNotifier,
-                                  simplificationTolerance: 0.0,
-                                  polygons: [
-                                    ...?polygons,
-                                    ...?selectPolygons,
-                                    ...?activePolygons,
-                                  ]),
-                            ]),
-                      ),
-                      SizedBox(
-                        width: constraints.maxWidth,
-                        height: indicatorHeight,
-                        child: Center(
-                          child: SmoothPageIndicator(
-                              controller: pageController, // PageController
-                              count: pageCount,
-                              effect: WormEffect(
-                                dotColor: colorScheme.surfaceContainerHighest,
-                                activeDotColor: colorScheme.primary,
-                              ), // your preferred effect
-                              onDotClicked: movePage),
-                        ),
-                      ),
-                      Container(
-                        width: constraints.maxWidth,
-                        height: usableHeight.toDouble(),
-                        constraints: const BoxConstraints(maxWidth: 480.0),
-                        child: PageView(
-                          controller: pageController,
-                          physics: const ClampingScrollPhysics(),
+                return Column(
+                  children: [
+                    SizedBox(
+                      width: constraints.maxWidth,
+                      height: maxHeight - usableHeight,
+                      child: FlutterMap(
+                          mapController: mapController,
+                          options: MapOptions(
+                            interactionOptions: const InteractionOptions(
+                                flags: InteractiveFlag.none),
+                            backgroundColor: colorScheme.surface,
+                            onMapReady: () {
+                              if (onMapReadyCompleter.isCompleted) return;
+                              onMapReadyCompleter.complete();
+                            },
+                          ),
                           children: [
-                            for (int i = 0; i < pageCount; i++)
-                              Center(
-                                child: Wrap(
-                                  runAlignment: WrapAlignment.start,
-                                  spacing: -0.5,
-                                  runSpacing: -0.5,
-                                  children: [
-                                    for (final child in children.sublist(
-                                        (itemsPerPage * i),
-                                        min((itemsPerPage * i) + itemsPerPage,
-                                            children.length)))
-                                      GeographySelectButton(
-                                          width: buttonWidth,
-                                          height: buttonHeight,
-                                          label: child.shortName,
-                                          isActive: child.id == activeChild?.id,
-                                          isSelected: widget.selectedChildren
-                                              .contains(child),
-                                          onPressed: () => ref
-                                              .read(geographySelectProvider(
-                                                      widget.id)
-                                                  .notifier)
-                                              .active(child))
-                                  ],
-                                ),
-                              ),
-                          ],
-                        ),
+                            PolygonLayer(
+                                hitNotifier: hitNotifier,
+                                simplificationTolerance: 0.0,
+                                polygons: [
+                                  ...?polygons,
+                                  ...?selectPolygons,
+                                  ...?activePolygons,
+                                ]),
+                          ]),
+                    ),
+                    SizedBox(
+                      width: constraints.maxWidth,
+                      height: indicatorHeight,
+                      child: Center(
+                        child: SmoothPageIndicator(
+                            controller: pageController, // PageController
+                            count: pageCount,
+                            effect: WormEffect(
+                              dotColor: colorScheme.surfaceContainerHighest,
+                              activeDotColor: colorScheme.primary,
+                            ), // your preferred effect
+                            onDotClicked: movePage),
                       ),
-                    ],
-                  );
-                });
+                    ),
+                    Container(
+                      width: constraints.maxWidth,
+                      height: usableHeight.toDouble(),
+                      constraints: const BoxConstraints(maxWidth: 480.0),
+                      child: PageView(
+                        controller: pageController,
+                        physics: const ClampingScrollPhysics(),
+                        children: [
+                          for (int i = 0; i < pageCount; i++)
+                            Center(
+                              child: Wrap(
+                                runAlignment: WrapAlignment.start,
+                                spacing: -0.5,
+                                runSpacing: -0.5,
+                                children: [
+                                  for (final child in children.sublist(
+                                      (itemsPerPage * i),
+                                      min((itemsPerPage * i) + itemsPerPage,
+                                          children.length)))
+                                    GeographySelectButton(
+                                        width: buttonWidth,
+                                        height: buttonHeight,
+                                        label: child.shortName,
+                                        isActive: child == curtActiveChild,
+                                        isSelected: widget.selectedChildren
+                                            .contains(child),
+                                        onPressed: () => ref
+                                            .read(geographySelectProvider(
+                                                    widget.id)
+                                                .notifier)
+                                            .active(child))
+                                ],
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ],
+                );
               }),
             ),
             bottomNavigationBar: Container(
@@ -283,8 +287,8 @@ class _StateSelectViewState extends ConsumerState<GeographySelectView> {
                   const SizedBox(width: 8.0),
                   Expanded(
                       child: FilledButton(
-                          onPressed: activeChild != null
-                              ? () => widget.onSelect(activeChild)
+                          onPressed: curtActiveChild != null
+                              ? () => widget.onSelect(curtActiveChild)
                               : null,
                           child: Text(
                               widget.selectedChildren.contains(activeChild) &&

--- a/application/lib/feature/geography_select/geography_select_view.dart
+++ b/application/lib/feature/geography_select/geography_select_view.dart
@@ -22,7 +22,6 @@ class GeographySelectView extends ConsumerStatefulWidget {
   final FutureOr<void> Function(GeographyModel model) onSelect;
   final VoidCallback? onCancel;
 
-  final GeographyModel? initialActiveChild;
   final Iterable<GeographyModel> selectedChildren;
 
   final bool isUnSelectable;
@@ -32,7 +31,6 @@ class GeographySelectView extends ConsumerStatefulWidget {
       required this.id,
       required this.onSelect,
       required this.selectedChildren,
-        this.initialActiveChild,
       this.onCancel,
       this.isUnSelectable = true});
 
@@ -160,9 +158,8 @@ class _StateSelectViewState extends ConsumerState<GeographySelectView> {
           if (polygons == null) {
             init(model, children);
           }
-          final curtActiveChild = activeChild ?? widget.initialActiveChild;
 
-          readyActivePolygon(curtActiveChild?.id);
+          readyActivePolygon(activeChild?.id);
           readySelectPolygon(widget.selectedChildren.map((child) => child.id));
 
           return Scaffold(
@@ -185,8 +182,8 @@ class _StateSelectViewState extends ConsumerState<GeographySelectView> {
                 final int pageCount = (children.length / itemsPerPage).ceil();
 
 
-                if (curtActiveChild != null) {
-                  final index = children.indexOf(curtActiveChild);
+                if (activeChild != null) {
+                  final index = children.indexOf(activeChild);
 
                   movePage((index / itemsPerPage).floor());
                 }
@@ -255,7 +252,7 @@ class _StateSelectViewState extends ConsumerState<GeographySelectView> {
                                         width: buttonWidth,
                                         height: buttonHeight,
                                         label: child.shortName,
-                                        isActive: child == curtActiveChild,
+                                        isActive: child == activeChild,
                                         isSelected: widget.selectedChildren
                                             .contains(child),
                                         onPressed: () => ref
@@ -286,8 +283,8 @@ class _StateSelectViewState extends ConsumerState<GeographySelectView> {
                   const SizedBox(width: 8.0),
                   Expanded(
                       child: FilledButton(
-                          onPressed: curtActiveChild != null
-                              ? () => widget.onSelect(curtActiveChild)
+                          onPressed: activeChild != null
+                              ? () => widget.onSelect(activeChild)
                               : null,
                           child: Text(
                               widget.selectedChildren.contains(activeChild) &&

--- a/application/lib/feature/geography_select/geography_select_view.dart
+++ b/application/lib/feature/geography_select/geography_select_view.dart
@@ -135,7 +135,6 @@ class _StateSelectViewState extends ConsumerState<GeographySelectView> {
     await onPageViewReadyCompleter.future;
 
     final curtIndex = pageController.page!.toInt();
-
     if (curtIndex == targetIndex) return;
 
     final mills = ((targetIndex - curtIndex).abs()) * 250;

--- a/application/lib/feature/geography_select/province_city_select_provider.dart
+++ b/application/lib/feature/geography_select/province_city_select_provider.dart
@@ -2,8 +2,7 @@ import 'package:application_new/domain/geography/geography_model.dart';
 import 'package:application_new/domain/geography/geography_provider.dart';
 import 'package:application_new/feature/geography_select/geography_select_provider.dart';
 import 'package:application_new/feature/geography_select/province_city_select_state.dart';
-import 'package:application_new/shared/dto/reference.dart';
-import 'package:application_new/shared/dto/reference_iterable.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'province_city_select_provider.g.dart';
@@ -12,18 +11,17 @@ part 'province_city_select_provider.g.dart';
 class ProvinceCitySelect extends _$ProvinceCitySelect {
   @override
   ProvinceCitySelectState build() {
+
+    ref.onDispose(() {
+      ref.invalidate(geographySelectProvider);
+    });
+
     return const ProvinceCitySelectState();
   }
 
   void activeProvince(ProvinceModel? province) {
     if (state.activeProvince == province) return;
     state = state.copyWith(activeProvince: province);
-  }
-
-  void activeCity(CityModel? city) {
-    if (state.activeCity == city || city == null) return;
-
-    state = state.copyWith(activeCity: city);
   }
 
   void selectProvince(ProvinceModel? province) {

--- a/application/lib/feature/geography_select/province_city_select_provider.dart
+++ b/application/lib/feature/geography_select/province_city_select_provider.dart
@@ -1,5 +1,6 @@
 import 'package:application_new/domain/geography/geography_model.dart';
 import 'package:application_new/domain/geography/geography_provider.dart';
+import 'package:application_new/feature/geography_select/geography_select_provider.dart';
 import 'package:application_new/feature/geography_select/province_city_select_state.dart';
 import 'package:application_new/shared/dto/reference.dart';
 import 'package:application_new/shared/dto/reference_iterable.dart';
@@ -17,6 +18,12 @@ class ProvinceCitySelect extends _$ProvinceCitySelect {
   void activeProvince(ProvinceModel? province) {
     if (state.activeProvince == province) return;
     state = state.copyWith(activeProvince: province);
+  }
+
+  void activeCity(CityModel? city) {
+    if (state.activeCity == city || city == null) return;
+
+    state = state.copyWith(activeCity: city);
   }
 
   void selectCity(CityModel city) async {

--- a/application/lib/feature/geography_select/province_city_select_provider.dart
+++ b/application/lib/feature/geography_select/province_city_select_provider.dart
@@ -1,5 +1,8 @@
 import 'package:application_new/domain/geography/geography_model.dart';
+import 'package:application_new/domain/geography/geography_provider.dart';
 import 'package:application_new/feature/geography_select/province_city_select_state.dart';
+import 'package:application_new/shared/dto/reference.dart';
+import 'package:application_new/shared/dto/reference_iterable.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'province_city_select_provider.g.dart';
@@ -11,21 +14,20 @@ class ProvinceCitySelect extends _$ProvinceCitySelect {
     return const ProvinceCitySelectState();
   }
 
-  void selectProvince(int id) {
-    if (state.selectedProvinceId == id) return;
-    state = state.copyWith(selectedProvinceId: id);
+  void activeProvince(ProvinceModel? province) {
+    if (state.activeProvince == province) return;
+    state = state.copyWith(activeProvince: province);
   }
 
-  void selectCity(CityModel city) {
-    final selectCities = List.of(state.selectedCities);
+  void selectCity(CityModel city) async {
+    final selectedCities = state.selectedCities;
 
-    if (selectCities.contains(city)) {
-      selectCities.remove(city);
-    } else {
-      selectCities.add(city);
+    if (selectedCities.contains(city)) {
+      state = state.copyWith(selectedCities: selectedCities.remove(city));
+      return;
     }
 
-    state = state.copyWith(selectedCities: selectCities);
+    final province = await ref.watch(provinceProvider(city.parentId).future);
+    state = state.copyWith(selectedCities: selectedCities.add(city, province));
   }
-
 }

--- a/application/lib/feature/geography_select/province_city_select_provider.dart
+++ b/application/lib/feature/geography_select/province_city_select_provider.dart
@@ -26,6 +26,11 @@ class ProvinceCitySelect extends _$ProvinceCitySelect {
     state = state.copyWith(activeCity: city);
   }
 
+  void selectProvince(ProvinceModel? province) {
+    if (state.selectProvince == province) return;
+    state = state.copyWith(selectProvince: province);
+  }
+
   void selectCity(CityModel city) async {
     final selectedCities = state.selectedCities;
 

--- a/application/lib/feature/geography_select/province_city_select_provider.g.dart
+++ b/application/lib/feature/geography_select/province_city_select_provider.g.dart
@@ -7,7 +7,7 @@ part of 'province_city_select_provider.dart';
 // **************************************************************************
 
 String _$provinceCitySelectHash() =>
-    r'a101c32f3bf9e0abd868d38bb3b3aa44741a1f3e';
+    r'd77f274d13a824e50f70916c27d3e030d24bd514';
 
 /// See also [ProvinceCitySelect].
 @ProviderFor(ProvinceCitySelect)

--- a/application/lib/feature/geography_select/province_city_select_provider.g.dart
+++ b/application/lib/feature/geography_select/province_city_select_provider.g.dart
@@ -7,7 +7,7 @@ part of 'province_city_select_provider.dart';
 // **************************************************************************
 
 String _$provinceCitySelectHash() =>
-    r'd77f274d13a824e50f70916c27d3e030d24bd514';
+    r'952e23127ac86df6ca4dc28cfe44812f00fccecd';
 
 /// See also [ProvinceCitySelect].
 @ProviderFor(ProvinceCitySelect)

--- a/application/lib/feature/geography_select/province_city_select_provider.g.dart
+++ b/application/lib/feature/geography_select/province_city_select_provider.g.dart
@@ -7,7 +7,7 @@ part of 'province_city_select_provider.dart';
 // **************************************************************************
 
 String _$provinceCitySelectHash() =>
-    r'952e23127ac86df6ca4dc28cfe44812f00fccecd';
+    r'c11d51fb586223db79d121a2a41a21d06dd71341';
 
 /// See also [ProvinceCitySelect].
 @ProviderFor(ProvinceCitySelect)

--- a/application/lib/feature/geography_select/province_city_select_provider.g.dart
+++ b/application/lib/feature/geography_select/province_city_select_provider.g.dart
@@ -7,7 +7,7 @@ part of 'province_city_select_provider.dart';
 // **************************************************************************
 
 String _$provinceCitySelectHash() =>
-    r'05c400e7582020494999cd9249823bcda0ed9ff0';
+    r'a101c32f3bf9e0abd868d38bb3b3aa44741a1f3e';
 
 /// See also [ProvinceCitySelect].
 @ProviderFor(ProvinceCitySelect)

--- a/application/lib/feature/geography_select/province_city_select_state.dart
+++ b/application/lib/feature/geography_select/province_city_select_state.dart
@@ -9,7 +9,6 @@ part 'province_city_select_state.freezed.dart';
 class ProvinceCitySelectState with _$ProvinceCitySelectState {
   const factory ProvinceCitySelectState({
     ProvinceModel? activeProvince,
-    CityModel? activeCity,
     ProvinceModel? selectProvince,
     @Default(ReferenceIterable())
     ReferenceIterable<CityModel, ProvinceModel> selectedCities,

--- a/application/lib/feature/geography_select/province_city_select_state.dart
+++ b/application/lib/feature/geography_select/province_city_select_state.dart
@@ -10,6 +10,7 @@ class ProvinceCitySelectState with _$ProvinceCitySelectState {
   const factory ProvinceCitySelectState({
     ProvinceModel? activeProvince,
     CityModel? activeCity,
+    ProvinceModel? selectProvince,
     @Default(ReferenceIterable())
     ReferenceIterable<CityModel, ProvinceModel> selectedCities,
   }) = _ProvinceCitySelectState;

--- a/application/lib/feature/geography_select/province_city_select_state.dart
+++ b/application/lib/feature/geography_select/province_city_select_state.dart
@@ -9,6 +9,7 @@ part 'province_city_select_state.freezed.dart';
 class ProvinceCitySelectState with _$ProvinceCitySelectState {
   const factory ProvinceCitySelectState({
     ProvinceModel? activeProvince,
+    CityModel? activeCity,
     @Default(ReferenceIterable())
     ReferenceIterable<CityModel, ProvinceModel> selectedCities,
   }) = _ProvinceCitySelectState;

--- a/application/lib/feature/geography_select/province_city_select_state.dart
+++ b/application/lib/feature/geography_select/province_city_select_state.dart
@@ -1,14 +1,15 @@
 import 'package:application_new/domain/geography/geography_model.dart';
+import 'package:application_new/shared/dto/reference.dart';
+import 'package:application_new/shared/dto/reference_iterable.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'province_city_select_state.freezed.dart';
 
 @freezed
 class ProvinceCitySelectState with _$ProvinceCitySelectState {
-
   const factory ProvinceCitySelectState({
-    int? selectedProvinceId,
-    @Default([]) List<CityModel> selectedCities,
+    ProvinceModel? activeProvince,
+    @Default(ReferenceIterable())
+    ReferenceIterable<CityModel, ProvinceModel> selectedCities,
   }) = _ProvinceCitySelectState;
-
 }

--- a/application/lib/feature/geography_select/province_city_select_state.freezed.dart
+++ b/application/lib/feature/geography_select/province_city_select_state.freezed.dart
@@ -16,8 +16,9 @@ final _privateConstructorUsedError = UnsupportedError(
 
 /// @nodoc
 mixin _$ProvinceCitySelectState {
-  int? get selectedProvinceId => throw _privateConstructorUsedError;
-  List<CityModel> get selectedCities => throw _privateConstructorUsedError;
+  ProvinceModel? get activeProvince => throw _privateConstructorUsedError;
+  ReferenceIterable<CityModel, ProvinceModel> get selectedCities =>
+      throw _privateConstructorUsedError;
 
   /// Create a copy of ProvinceCitySelectState
   /// with the given fields replaced by the non-null parameter values.
@@ -32,7 +33,9 @@ abstract class $ProvinceCitySelectStateCopyWith<$Res> {
           $Res Function(ProvinceCitySelectState) then) =
       _$ProvinceCitySelectStateCopyWithImpl<$Res, ProvinceCitySelectState>;
   @useResult
-  $Res call({int? selectedProvinceId, List<CityModel> selectedCities});
+  $Res call(
+      {ProvinceModel? activeProvince,
+      ReferenceIterable<CityModel, ProvinceModel> selectedCities});
 }
 
 /// @nodoc
@@ -51,18 +54,18 @@ class _$ProvinceCitySelectStateCopyWithImpl<$Res,
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? selectedProvinceId = freezed,
+    Object? activeProvince = freezed,
     Object? selectedCities = null,
   }) {
     return _then(_value.copyWith(
-      selectedProvinceId: freezed == selectedProvinceId
-          ? _value.selectedProvinceId
-          : selectedProvinceId // ignore: cast_nullable_to_non_nullable
-              as int?,
+      activeProvince: freezed == activeProvince
+          ? _value.activeProvince
+          : activeProvince // ignore: cast_nullable_to_non_nullable
+              as ProvinceModel?,
       selectedCities: null == selectedCities
           ? _value.selectedCities
           : selectedCities // ignore: cast_nullable_to_non_nullable
-              as List<CityModel>,
+              as ReferenceIterable<CityModel, ProvinceModel>,
     ) as $Val);
   }
 }
@@ -76,7 +79,9 @@ abstract class _$$ProvinceCitySelectStateImplCopyWith<$Res>
       __$$ProvinceCitySelectStateImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({int? selectedProvinceId, List<CityModel> selectedCities});
+  $Res call(
+      {ProvinceModel? activeProvince,
+      ReferenceIterable<CityModel, ProvinceModel> selectedCities});
 }
 
 /// @nodoc
@@ -94,18 +99,18 @@ class __$$ProvinceCitySelectStateImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? selectedProvinceId = freezed,
+    Object? activeProvince = freezed,
     Object? selectedCities = null,
   }) {
     return _then(_$ProvinceCitySelectStateImpl(
-      selectedProvinceId: freezed == selectedProvinceId
-          ? _value.selectedProvinceId
-          : selectedProvinceId // ignore: cast_nullable_to_non_nullable
-              as int?,
+      activeProvince: freezed == activeProvince
+          ? _value.activeProvince
+          : activeProvince // ignore: cast_nullable_to_non_nullable
+              as ProvinceModel?,
       selectedCities: null == selectedCities
-          ? _value._selectedCities
+          ? _value.selectedCities
           : selectedCities // ignore: cast_nullable_to_non_nullable
-              as List<CityModel>,
+              as ReferenceIterable<CityModel, ProvinceModel>,
     ));
   }
 }
@@ -114,24 +119,17 @@ class __$$ProvinceCitySelectStateImplCopyWithImpl<$Res>
 
 class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
   const _$ProvinceCitySelectStateImpl(
-      {this.selectedProvinceId,
-      final List<CityModel> selectedCities = const []})
-      : _selectedCities = selectedCities;
+      {this.activeProvince, this.selectedCities = const ReferenceIterable()});
 
   @override
-  final int? selectedProvinceId;
-  final List<CityModel> _selectedCities;
+  final ProvinceModel? activeProvince;
   @override
   @JsonKey()
-  List<CityModel> get selectedCities {
-    if (_selectedCities is EqualUnmodifiableListView) return _selectedCities;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_selectedCities);
-  }
+  final ReferenceIterable<CityModel, ProvinceModel> selectedCities;
 
   @override
   String toString() {
-    return 'ProvinceCitySelectState(selectedProvinceId: $selectedProvinceId, selectedCities: $selectedCities)';
+    return 'ProvinceCitySelectState(activeProvince: $activeProvince, selectedCities: $selectedCities)';
   }
 
   @override
@@ -139,15 +137,15 @@ class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ProvinceCitySelectStateImpl &&
-            (identical(other.selectedProvinceId, selectedProvinceId) ||
-                other.selectedProvinceId == selectedProvinceId) &&
             const DeepCollectionEquality()
-                .equals(other._selectedCities, _selectedCities));
+                .equals(other.activeProvince, activeProvince) &&
+            (identical(other.selectedCities, selectedCities) ||
+                other.selectedCities == selectedCities));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, selectedProvinceId,
-      const DeepCollectionEquality().hash(_selectedCities));
+  int get hashCode => Object.hash(runtimeType,
+      const DeepCollectionEquality().hash(activeProvince), selectedCities);
 
   /// Create a copy of ProvinceCitySelectState
   /// with the given fields replaced by the non-null parameter values.
@@ -161,13 +159,14 @@ class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
 
 abstract class _ProvinceCitySelectState implements ProvinceCitySelectState {
   const factory _ProvinceCitySelectState(
-      {final int? selectedProvinceId,
-      final List<CityModel> selectedCities}) = _$ProvinceCitySelectStateImpl;
+          {final ProvinceModel? activeProvince,
+          final ReferenceIterable<CityModel, ProvinceModel> selectedCities}) =
+      _$ProvinceCitySelectStateImpl;
 
   @override
-  int? get selectedProvinceId;
+  ProvinceModel? get activeProvince;
   @override
-  List<CityModel> get selectedCities;
+  ReferenceIterable<CityModel, ProvinceModel> get selectedCities;
 
   /// Create a copy of ProvinceCitySelectState
   /// with the given fields replaced by the non-null parameter values.

--- a/application/lib/feature/geography_select/province_city_select_state.freezed.dart
+++ b/application/lib/feature/geography_select/province_city_select_state.freezed.dart
@@ -18,6 +18,7 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$ProvinceCitySelectState {
   ProvinceModel? get activeProvince => throw _privateConstructorUsedError;
   CityModel? get activeCity => throw _privateConstructorUsedError;
+  ProvinceModel? get selectProvince => throw _privateConstructorUsedError;
   ReferenceIterable<CityModel, ProvinceModel> get selectedCities =>
       throw _privateConstructorUsedError;
 
@@ -37,6 +38,7 @@ abstract class $ProvinceCitySelectStateCopyWith<$Res> {
   $Res call(
       {ProvinceModel? activeProvince,
       CityModel? activeCity,
+      ProvinceModel? selectProvince,
       ReferenceIterable<CityModel, ProvinceModel> selectedCities});
 }
 
@@ -58,6 +60,7 @@ class _$ProvinceCitySelectStateCopyWithImpl<$Res,
   $Res call({
     Object? activeProvince = freezed,
     Object? activeCity = freezed,
+    Object? selectProvince = freezed,
     Object? selectedCities = null,
   }) {
     return _then(_value.copyWith(
@@ -69,6 +72,10 @@ class _$ProvinceCitySelectStateCopyWithImpl<$Res,
           ? _value.activeCity
           : activeCity // ignore: cast_nullable_to_non_nullable
               as CityModel?,
+      selectProvince: freezed == selectProvince
+          ? _value.selectProvince
+          : selectProvince // ignore: cast_nullable_to_non_nullable
+              as ProvinceModel?,
       selectedCities: null == selectedCities
           ? _value.selectedCities
           : selectedCities // ignore: cast_nullable_to_non_nullable
@@ -89,6 +96,7 @@ abstract class _$$ProvinceCitySelectStateImplCopyWith<$Res>
   $Res call(
       {ProvinceModel? activeProvince,
       CityModel? activeCity,
+      ProvinceModel? selectProvince,
       ReferenceIterable<CityModel, ProvinceModel> selectedCities});
 }
 
@@ -109,6 +117,7 @@ class __$$ProvinceCitySelectStateImplCopyWithImpl<$Res>
   $Res call({
     Object? activeProvince = freezed,
     Object? activeCity = freezed,
+    Object? selectProvince = freezed,
     Object? selectedCities = null,
   }) {
     return _then(_$ProvinceCitySelectStateImpl(
@@ -120,6 +129,10 @@ class __$$ProvinceCitySelectStateImplCopyWithImpl<$Res>
           ? _value.activeCity
           : activeCity // ignore: cast_nullable_to_non_nullable
               as CityModel?,
+      selectProvince: freezed == selectProvince
+          ? _value.selectProvince
+          : selectProvince // ignore: cast_nullable_to_non_nullable
+              as ProvinceModel?,
       selectedCities: null == selectedCities
           ? _value.selectedCities
           : selectedCities // ignore: cast_nullable_to_non_nullable
@@ -134,6 +147,7 @@ class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
   const _$ProvinceCitySelectStateImpl(
       {this.activeProvince,
       this.activeCity,
+      this.selectProvince,
       this.selectedCities = const ReferenceIterable()});
 
   @override
@@ -141,12 +155,14 @@ class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
   @override
   final CityModel? activeCity;
   @override
+  final ProvinceModel? selectProvince;
+  @override
   @JsonKey()
   final ReferenceIterable<CityModel, ProvinceModel> selectedCities;
 
   @override
   String toString() {
-    return 'ProvinceCitySelectState(activeProvince: $activeProvince, activeCity: $activeCity, selectedCities: $selectedCities)';
+    return 'ProvinceCitySelectState(activeProvince: $activeProvince, activeCity: $activeCity, selectProvince: $selectProvince, selectedCities: $selectedCities)';
   }
 
   @override
@@ -158,6 +174,8 @@ class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
                 .equals(other.activeProvince, activeProvince) &&
             const DeepCollectionEquality()
                 .equals(other.activeCity, activeCity) &&
+            const DeepCollectionEquality()
+                .equals(other.selectProvince, selectProvince) &&
             (identical(other.selectedCities, selectedCities) ||
                 other.selectedCities == selectedCities));
   }
@@ -167,6 +185,7 @@ class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
       runtimeType,
       const DeepCollectionEquality().hash(activeProvince),
       const DeepCollectionEquality().hash(activeCity),
+      const DeepCollectionEquality().hash(selectProvince),
       selectedCities);
 
   /// Create a copy of ProvinceCitySelectState
@@ -183,6 +202,7 @@ abstract class _ProvinceCitySelectState implements ProvinceCitySelectState {
   const factory _ProvinceCitySelectState(
           {final ProvinceModel? activeProvince,
           final CityModel? activeCity,
+          final ProvinceModel? selectProvince,
           final ReferenceIterable<CityModel, ProvinceModel> selectedCities}) =
       _$ProvinceCitySelectStateImpl;
 
@@ -190,6 +210,8 @@ abstract class _ProvinceCitySelectState implements ProvinceCitySelectState {
   ProvinceModel? get activeProvince;
   @override
   CityModel? get activeCity;
+  @override
+  ProvinceModel? get selectProvince;
   @override
   ReferenceIterable<CityModel, ProvinceModel> get selectedCities;
 

--- a/application/lib/feature/geography_select/province_city_select_state.freezed.dart
+++ b/application/lib/feature/geography_select/province_city_select_state.freezed.dart
@@ -17,7 +17,6 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$ProvinceCitySelectState {
   ProvinceModel? get activeProvince => throw _privateConstructorUsedError;
-  CityModel? get activeCity => throw _privateConstructorUsedError;
   ProvinceModel? get selectProvince => throw _privateConstructorUsedError;
   ReferenceIterable<CityModel, ProvinceModel> get selectedCities =>
       throw _privateConstructorUsedError;
@@ -37,7 +36,6 @@ abstract class $ProvinceCitySelectStateCopyWith<$Res> {
   @useResult
   $Res call(
       {ProvinceModel? activeProvince,
-      CityModel? activeCity,
       ProvinceModel? selectProvince,
       ReferenceIterable<CityModel, ProvinceModel> selectedCities});
 }
@@ -59,7 +57,6 @@ class _$ProvinceCitySelectStateCopyWithImpl<$Res,
   @override
   $Res call({
     Object? activeProvince = freezed,
-    Object? activeCity = freezed,
     Object? selectProvince = freezed,
     Object? selectedCities = null,
   }) {
@@ -68,10 +65,6 @@ class _$ProvinceCitySelectStateCopyWithImpl<$Res,
           ? _value.activeProvince
           : activeProvince // ignore: cast_nullable_to_non_nullable
               as ProvinceModel?,
-      activeCity: freezed == activeCity
-          ? _value.activeCity
-          : activeCity // ignore: cast_nullable_to_non_nullable
-              as CityModel?,
       selectProvince: freezed == selectProvince
           ? _value.selectProvince
           : selectProvince // ignore: cast_nullable_to_non_nullable
@@ -95,7 +88,6 @@ abstract class _$$ProvinceCitySelectStateImplCopyWith<$Res>
   @useResult
   $Res call(
       {ProvinceModel? activeProvince,
-      CityModel? activeCity,
       ProvinceModel? selectProvince,
       ReferenceIterable<CityModel, ProvinceModel> selectedCities});
 }
@@ -116,7 +108,6 @@ class __$$ProvinceCitySelectStateImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? activeProvince = freezed,
-    Object? activeCity = freezed,
     Object? selectProvince = freezed,
     Object? selectedCities = null,
   }) {
@@ -125,10 +116,6 @@ class __$$ProvinceCitySelectStateImplCopyWithImpl<$Res>
           ? _value.activeProvince
           : activeProvince // ignore: cast_nullable_to_non_nullable
               as ProvinceModel?,
-      activeCity: freezed == activeCity
-          ? _value.activeCity
-          : activeCity // ignore: cast_nullable_to_non_nullable
-              as CityModel?,
       selectProvince: freezed == selectProvince
           ? _value.selectProvince
           : selectProvince // ignore: cast_nullable_to_non_nullable
@@ -146,14 +133,11 @@ class __$$ProvinceCitySelectStateImplCopyWithImpl<$Res>
 class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
   const _$ProvinceCitySelectStateImpl(
       {this.activeProvince,
-      this.activeCity,
       this.selectProvince,
       this.selectedCities = const ReferenceIterable()});
 
   @override
   final ProvinceModel? activeProvince;
-  @override
-  final CityModel? activeCity;
   @override
   final ProvinceModel? selectProvince;
   @override
@@ -162,7 +146,7 @@ class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
 
   @override
   String toString() {
-    return 'ProvinceCitySelectState(activeProvince: $activeProvince, activeCity: $activeCity, selectProvince: $selectProvince, selectedCities: $selectedCities)';
+    return 'ProvinceCitySelectState(activeProvince: $activeProvince, selectProvince: $selectProvince, selectedCities: $selectedCities)';
   }
 
   @override
@@ -173,8 +157,6 @@ class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
             const DeepCollectionEquality()
                 .equals(other.activeProvince, activeProvince) &&
             const DeepCollectionEquality()
-                .equals(other.activeCity, activeCity) &&
-            const DeepCollectionEquality()
                 .equals(other.selectProvince, selectProvince) &&
             (identical(other.selectedCities, selectedCities) ||
                 other.selectedCities == selectedCities));
@@ -184,7 +166,6 @@ class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
   int get hashCode => Object.hash(
       runtimeType,
       const DeepCollectionEquality().hash(activeProvince),
-      const DeepCollectionEquality().hash(activeCity),
       const DeepCollectionEquality().hash(selectProvince),
       selectedCities);
 
@@ -201,15 +182,12 @@ class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
 abstract class _ProvinceCitySelectState implements ProvinceCitySelectState {
   const factory _ProvinceCitySelectState(
           {final ProvinceModel? activeProvince,
-          final CityModel? activeCity,
           final ProvinceModel? selectProvince,
           final ReferenceIterable<CityModel, ProvinceModel> selectedCities}) =
       _$ProvinceCitySelectStateImpl;
 
   @override
   ProvinceModel? get activeProvince;
-  @override
-  CityModel? get activeCity;
   @override
   ProvinceModel? get selectProvince;
   @override

--- a/application/lib/feature/geography_select/province_city_select_state.freezed.dart
+++ b/application/lib/feature/geography_select/province_city_select_state.freezed.dart
@@ -17,6 +17,7 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$ProvinceCitySelectState {
   ProvinceModel? get activeProvince => throw _privateConstructorUsedError;
+  CityModel? get activeCity => throw _privateConstructorUsedError;
   ReferenceIterable<CityModel, ProvinceModel> get selectedCities =>
       throw _privateConstructorUsedError;
 
@@ -35,6 +36,7 @@ abstract class $ProvinceCitySelectStateCopyWith<$Res> {
   @useResult
   $Res call(
       {ProvinceModel? activeProvince,
+      CityModel? activeCity,
       ReferenceIterable<CityModel, ProvinceModel> selectedCities});
 }
 
@@ -55,6 +57,7 @@ class _$ProvinceCitySelectStateCopyWithImpl<$Res,
   @override
   $Res call({
     Object? activeProvince = freezed,
+    Object? activeCity = freezed,
     Object? selectedCities = null,
   }) {
     return _then(_value.copyWith(
@@ -62,6 +65,10 @@ class _$ProvinceCitySelectStateCopyWithImpl<$Res,
           ? _value.activeProvince
           : activeProvince // ignore: cast_nullable_to_non_nullable
               as ProvinceModel?,
+      activeCity: freezed == activeCity
+          ? _value.activeCity
+          : activeCity // ignore: cast_nullable_to_non_nullable
+              as CityModel?,
       selectedCities: null == selectedCities
           ? _value.selectedCities
           : selectedCities // ignore: cast_nullable_to_non_nullable
@@ -81,6 +88,7 @@ abstract class _$$ProvinceCitySelectStateImplCopyWith<$Res>
   @useResult
   $Res call(
       {ProvinceModel? activeProvince,
+      CityModel? activeCity,
       ReferenceIterable<CityModel, ProvinceModel> selectedCities});
 }
 
@@ -100,6 +108,7 @@ class __$$ProvinceCitySelectStateImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? activeProvince = freezed,
+    Object? activeCity = freezed,
     Object? selectedCities = null,
   }) {
     return _then(_$ProvinceCitySelectStateImpl(
@@ -107,6 +116,10 @@ class __$$ProvinceCitySelectStateImplCopyWithImpl<$Res>
           ? _value.activeProvince
           : activeProvince // ignore: cast_nullable_to_non_nullable
               as ProvinceModel?,
+      activeCity: freezed == activeCity
+          ? _value.activeCity
+          : activeCity // ignore: cast_nullable_to_non_nullable
+              as CityModel?,
       selectedCities: null == selectedCities
           ? _value.selectedCities
           : selectedCities // ignore: cast_nullable_to_non_nullable
@@ -119,17 +132,21 @@ class __$$ProvinceCitySelectStateImplCopyWithImpl<$Res>
 
 class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
   const _$ProvinceCitySelectStateImpl(
-      {this.activeProvince, this.selectedCities = const ReferenceIterable()});
+      {this.activeProvince,
+      this.activeCity,
+      this.selectedCities = const ReferenceIterable()});
 
   @override
   final ProvinceModel? activeProvince;
+  @override
+  final CityModel? activeCity;
   @override
   @JsonKey()
   final ReferenceIterable<CityModel, ProvinceModel> selectedCities;
 
   @override
   String toString() {
-    return 'ProvinceCitySelectState(activeProvince: $activeProvince, selectedCities: $selectedCities)';
+    return 'ProvinceCitySelectState(activeProvince: $activeProvince, activeCity: $activeCity, selectedCities: $selectedCities)';
   }
 
   @override
@@ -139,13 +156,18 @@ class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
             other is _$ProvinceCitySelectStateImpl &&
             const DeepCollectionEquality()
                 .equals(other.activeProvince, activeProvince) &&
+            const DeepCollectionEquality()
+                .equals(other.activeCity, activeCity) &&
             (identical(other.selectedCities, selectedCities) ||
                 other.selectedCities == selectedCities));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType,
-      const DeepCollectionEquality().hash(activeProvince), selectedCities);
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(activeProvince),
+      const DeepCollectionEquality().hash(activeCity),
+      selectedCities);
 
   /// Create a copy of ProvinceCitySelectState
   /// with the given fields replaced by the non-null parameter values.
@@ -160,11 +182,14 @@ class _$ProvinceCitySelectStateImpl implements _ProvinceCitySelectState {
 abstract class _ProvinceCitySelectState implements ProvinceCitySelectState {
   const factory _ProvinceCitySelectState(
           {final ProvinceModel? activeProvince,
+          final CityModel? activeCity,
           final ReferenceIterable<CityModel, ProvinceModel> selectedCities}) =
       _$ProvinceCitySelectStateImpl;
 
   @override
   ProvinceModel? get activeProvince;
+  @override
+  CityModel? get activeCity;
   @override
   ReferenceIterable<CityModel, ProvinceModel> get selectedCities;
 

--- a/application/lib/feature/geography_select/province_city_select_view.dart
+++ b/application/lib/feature/geography_select/province_city_select_view.dart
@@ -35,10 +35,9 @@ class ProvinceCitySelectView extends ConsumerWidget {
     final state = ref.watch(provinceCitySelectProvider);
 
     final ProvinceCitySelectState(
-    :selectProvince,
+      :selectProvince,
       :selectedCities,
       :activeProvince,
-      :activeCity
     ) = state;
 
     final colorScheme = Theme.of(context).colorScheme;
@@ -64,30 +63,28 @@ class ProvinceCitySelectView extends ConsumerWidget {
       }
 
       if (prev?.selectProvince != next.selectProvince) {
-        if (next.selectProvince != null) nextPage();
-        else previousPage();
+        if (next.selectProvince != null) {
+          nextPage();
+        } else {
+          previousPage();
+        }
       }
     });
 
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            const SizedBox(width: 24.0),
-            Consumer(builder: (context, ref, child) {
-              const textStyle =
-                  TextStyle(fontWeight: FontWeight.w800, fontSize: 21.0);
-
-              if (selectProvince == null) {
-                return Text(tr.from('Please select a province.'),
-                    style: textStyle);
-              }
-
-              return Text(selectProvince.name ?? '', style: textStyle);
-            }),
-            const Expanded(child: SizedBox(width: 8.0)),
-            IconButton.filledTonal(
+    return Scaffold(
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+        title: Text(
+          selectProvince == null
+              ? tr.from('Please select a province.')
+              : selectProvince.name,
+          style: const TextStyle(fontSize: 20.0),
+        ),
+        shape: const Border(),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 16.0),
+            child: IconButton.filledTonal(
                 onPressed: () =>
                     SelectedCitiesListSheet.showSheet(context, state: state),
                 icon: badges.Badge(
@@ -101,51 +98,53 @@ class ProvinceCitySelectView extends ConsumerWidget {
                       padding: const EdgeInsets.all(6.0),
                     ),
                     child: const Icon(Icons.shopping_cart_outlined))),
-            const SizedBox(width: 24.0),
-          ],
-        ),
-        const SizedBox(height: 16.0),
-        Expanded(
-          child: PageView(
-            physics: const NeverScrollableScrollPhysics(),
-            controller: pageController,
-            children: [
-              GeographySelectView(
-                  id: countryId,
-                  selectedChildren: selectedCities.mapToReference(),
-                  initialActiveChild: activeProvince,
-                  isUnSelectable: false,
-                  onSelect: (model) {
-                    final notifier =
-                        ref.read(provinceCitySelectProvider.notifier);
-
-                    model.mapOrNull(province: (province) {
-                      notifier.activeProvince(province);
-                      notifier.selectProvince(province);
-                    });
-                  }),
-              SizedBox(
-                child: selectProvince != null
-                    ? GeographySelectView(
-                        selectedChildren: selectedCities.mapToEntity(),
-                        id: selectProvince.id,
-                        initialActiveChild: activeCity,
-                        onSelect: (model) => model.mapOrNull(
-                            city: (city) => ref
-                                .read(provinceCitySelectProvider.notifier)
-                                .selectCity(city)),
-                        onCancel: () {
-                          ref
-                              .read(provinceCitySelectProvider.notifier)
-                              .selectProvince(null);
-                        },
-                      )
-                    : const SizedBox(),
-              )
-            ],
           ),
-        ),
-      ],
+        ],
+      ),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          const SizedBox(height: 16.0),
+          Expanded(
+            child: PageView(
+              physics: const NeverScrollableScrollPhysics(),
+              controller: pageController,
+              children: [
+                GeographySelectView(
+                    id: countryId,
+                    selectedChildren: selectedCities.mapToReference(),
+                    isUnSelectable: false,
+                    onSelect: (model) {
+                      final notifier =
+                          ref.read(provinceCitySelectProvider.notifier);
+
+                      model.mapOrNull(province: (province) {
+                        notifier.activeProvince(province);
+                        notifier.selectProvince(province);
+                      });
+                    }),
+                SizedBox(
+                  child: selectProvince != null
+                      ? GeographySelectView(
+                          selectedChildren: selectedCities.mapToEntity(),
+                          id: selectProvince.id,
+                          onSelect: (model) => model.mapOrNull(
+                              city: (city) => ref
+                                  .read(provinceCitySelectProvider.notifier)
+                                  .selectCity(city)),
+                          onCancel: () {
+                            ref
+                                .read(provinceCitySelectProvider.notifier)
+                                .selectProvince(null);
+                          },
+                        )
+                      : const SizedBox(),
+                )
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/application/lib/feature/geography_select/selected_cities_list_sheet.dart
+++ b/application/lib/feature/geography_select/selected_cities_list_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:application_new/core/translation/translation_service.dart';
 import 'package:application_new/domain/geography/geography_model.dart';
+import 'package:application_new/feature/geography_select/geography_select_provider.dart';
 import 'package:application_new/feature/geography_select/province_city_select_provider.dart';
 import 'package:application_new/feature/geography_select/province_city_select_state.dart';
 import 'package:application_new/shared/dto/reference.dart';
@@ -44,7 +45,16 @@ class SelectedCitiesListSheet extends ConsumerWidget {
 
           return ListTile(
             onTap: () {
-              Navigator.of(context).pop(cityRef);
+              final notifier = ref.read(provinceCitySelectProvider.notifier);
+
+              // 최초 선택된 도시 값 반영을 위해 invalidate 수행
+              notifier.activeCity(cityRef.entity);
+              ref.invalidate(geographySelectProvider(cityRef.reference.id));
+
+              notifier.activeProvince(cityRef.reference);
+              notifier.selectProvince(cityRef.reference);
+
+              Navigator.of(context).pop();
             },
             contentPadding: const EdgeInsets.symmetric(horizontal: 24.0),
             leading: CircleAvatar(

--- a/application/lib/feature/geography_select/selected_cities_list_sheet.dart
+++ b/application/lib/feature/geography_select/selected_cities_list_sheet.dart
@@ -1,0 +1,74 @@
+import 'package:application_new/core/translation/translation_service.dart';
+import 'package:application_new/feature/geography_select/province_city_select_provider.dart';
+import 'package:application_new/feature/geography_select/province_city_select_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class SelectedCitiesListSheet extends ConsumerWidget {
+  final ProvinceCitySelectState state;
+
+  const SelectedCitiesListSheet._({required this.state});
+
+  static void showSheet(
+    BuildContext context, {
+    required ProvinceCitySelectState state,
+  }) =>
+      showModalBottomSheet(
+        context: context,
+        useSafeArea: true,
+        showDragHandle: true,
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        clipBehavior: Clip.hardEdge,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(8.0)),
+        ),
+        builder: (context) => SelectedCitiesListSheet._(state: state),
+      );
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ProvinceCitySelectState(:selectedCities) = state;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final tr = ref.watch(translationServiceProvider);
+
+    return Scaffold(
+      body: ListView.builder(
+        padding: const EdgeInsets.only(bottom: 24.0),
+        physics: const ClampingScrollPhysics(),
+        itemCount: selectedCities.length,
+        itemBuilder: (context, index) {
+          final cityRef = selectedCities.get(index);
+
+          return ListTile(
+            contentPadding: const EdgeInsets.symmetric(horizontal: 24.0),
+            leading: CircleAvatar(
+              radius: 16.0,
+              backgroundColor: colorScheme.surfaceContainer,
+              child: Text('${index + 1}',
+                  style: const TextStyle(fontWeight: FontWeight.w800)),
+            ),
+            title: Text(
+              cityRef.entity.name,
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+            subtitle: Text(cityRef.reference.name),
+            trailing: IconButton(
+                onPressed: () {},
+                icon: Icon(color: colorScheme.error, Icons.delete_outlined)),
+          );
+        },
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Container(
+          decoration: BoxDecoration(
+              border: Border(
+                  top: BorderSide(color: colorScheme.surfaceContainerHighest))),
+          padding: const EdgeInsets.fromLTRB(24.0, 16.0, 24.0, 0.0),
+          child:
+              FilledButton(onPressed: () {}, child: Text(tr.from('Confirm'))),
+        ),
+      ),
+    );
+  }
+}

--- a/application/lib/feature/geography_select/selected_cities_list_sheet.dart
+++ b/application/lib/feature/geography_select/selected_cities_list_sheet.dart
@@ -1,6 +1,8 @@
 import 'package:application_new/core/translation/translation_service.dart';
+import 'package:application_new/domain/geography/geography_model.dart';
 import 'package:application_new/feature/geography_select/province_city_select_provider.dart';
 import 'package:application_new/feature/geography_select/province_city_select_state.dart';
+import 'package:application_new/shared/dto/reference.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -9,7 +11,7 @@ class SelectedCitiesListSheet extends ConsumerWidget {
 
   const SelectedCitiesListSheet._({required this.state});
 
-  static void showSheet(
+  static Future<Reference<CityModel, ProvinceModel>?> showSheet(
     BuildContext context, {
     required ProvinceCitySelectState state,
   }) =>
@@ -41,6 +43,9 @@ class SelectedCitiesListSheet extends ConsumerWidget {
           final cityRef = selectedCities.get(index);
 
           return ListTile(
+            onTap: () {
+              Navigator.of(context).pop(cityRef);
+            },
             contentPadding: const EdgeInsets.symmetric(horizontal: 24.0),
             leading: CircleAvatar(
               radius: 16.0,

--- a/application/lib/feature/geography_select/selected_cities_list_sheet.dart
+++ b/application/lib/feature/geography_select/selected_cities_list_sheet.dart
@@ -48,8 +48,8 @@ class SelectedCitiesListSheet extends ConsumerWidget {
               final notifier = ref.read(provinceCitySelectProvider.notifier);
 
               // 최초 선택된 도시 값 반영을 위해 invalidate 수행
-              notifier.activeCity(cityRef.entity);
-              ref.invalidate(geographySelectProvider(cityRef.reference.id));
+              ref.read(geographySelectProvider(cityRef.reference.id).notifier)
+              .active(cityRef.entity);
 
               notifier.activeProvince(cityRef.reference);
               notifier.selectProvince(cityRef.reference);

--- a/application/lib/feature/travel_plan/page/travel_plan_manage/page/travel_plan_mange_list_view.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_manage/page/travel_plan_mange_list_view.dart
@@ -145,7 +145,7 @@ class _TravelPlanMangeListViewState
             ])),
         Align(
           alignment: Alignment.topCenter,
-          child: DragTarget<TravelVisitWithPlaceModel>(
+          child: DragTarget<TravelPlanModel>(
             builder: (context, accepted, rejected) => Container(
               height: 40,
               width: double.infinity,
@@ -156,7 +156,7 @@ class _TravelPlanMangeListViewState
         ),
         Align(
           alignment: Alignment.bottomCenter,
-          child: DragTarget<TravelVisitWithPlaceModel>(
+          child: DragTarget<TravelPlanModel>(
             builder: (context, accepted, rejected) => Container(
               height: 40,
               width: double.infinity,

--- a/application/lib/main.dart
+++ b/application/lib/main.dart
@@ -28,12 +28,13 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await EasyLocalization.ensureInitialized();
 
-  FlutterError.onError = (details) => handleException(details.exception, details.stack);
+  FlutterError.onError =
+      (details) => handleException(details.exception, details.stack);
   PlatformDispatcher.instance.onError = handleException;
 
   const korean = Locale.fromSubtags(languageCode: 'ko');
   const english = Locale.fromSubtags(languageCode: 'en');
-  
+
   timeago.setLocaleMessages('ko', timeago.KoMessages());
 
   runApp(EasyLocalization(
@@ -68,7 +69,7 @@ class _MyAppState extends ConsumerState<MyApp> {
 
     eventController.stream.listen((event) {
       switch (event) {
-        case MessageEvent(:final message, :final onCancel):
+        case MessageEvent(:final message, :final onActionRef):
           final ThemeData(:colorScheme) = Theme.of(themeKey.currentContext!);
 
           messengerKey.currentState?.hideCurrentSnackBar();
@@ -77,10 +78,14 @@ class _MyAppState extends ConsumerState<MyApp> {
                 backgroundColor: colorScheme.primaryContainer,
                 content: Text(message,
                     style: TextStyle(
-                        color: colorScheme.primary,
+                        color: colorScheme.onSurface,
                         fontWeight: FontWeight.w600)),
-                action: onCancel != null
-                    ? SnackBarAction(label: '취소', onPressed: onCancel)
+                action: onActionRef != null
+                    ? SnackBarAction(
+                        backgroundColor: colorScheme.surface,
+                        textColor: colorScheme.onSurface,
+                        label: onActionRef.entity,
+                        onPressed: onActionRef.reference)
                     : null),
           );
       }

--- a/application/lib/shared/dto/reference.dart
+++ b/application/lib/shared/dto/reference.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'reference.freezed.dart';
+
+@freezed
+class Reference<T, R> with _$Reference<T, R> {
+  const factory Reference({
+    required T entity,
+    required R reference,
+  }) = _Reference;
+}

--- a/application/lib/shared/dto/reference.freezed.dart
+++ b/application/lib/shared/dto/reference.freezed.dart
@@ -1,0 +1,165 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'reference.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$Reference<T, R> {
+  T get entity => throw _privateConstructorUsedError;
+  R get reference => throw _privateConstructorUsedError;
+
+  /// Create a copy of Reference
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ReferenceCopyWith<T, R, Reference<T, R>> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ReferenceCopyWith<T, R, $Res> {
+  factory $ReferenceCopyWith(
+          Reference<T, R> value, $Res Function(Reference<T, R>) then) =
+      _$ReferenceCopyWithImpl<T, R, $Res, Reference<T, R>>;
+  @useResult
+  $Res call({T entity, R reference});
+}
+
+/// @nodoc
+class _$ReferenceCopyWithImpl<T, R, $Res, $Val extends Reference<T, R>>
+    implements $ReferenceCopyWith<T, R, $Res> {
+  _$ReferenceCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Reference
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? entity = freezed,
+    Object? reference = freezed,
+  }) {
+    return _then(_value.copyWith(
+      entity: freezed == entity
+          ? _value.entity
+          : entity // ignore: cast_nullable_to_non_nullable
+              as T,
+      reference: freezed == reference
+          ? _value.reference
+          : reference // ignore: cast_nullable_to_non_nullable
+              as R,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ReferenceImplCopyWith<T, R, $Res>
+    implements $ReferenceCopyWith<T, R, $Res> {
+  factory _$$ReferenceImplCopyWith(_$ReferenceImpl<T, R> value,
+          $Res Function(_$ReferenceImpl<T, R>) then) =
+      __$$ReferenceImplCopyWithImpl<T, R, $Res>;
+  @override
+  @useResult
+  $Res call({T entity, R reference});
+}
+
+/// @nodoc
+class __$$ReferenceImplCopyWithImpl<T, R, $Res>
+    extends _$ReferenceCopyWithImpl<T, R, $Res, _$ReferenceImpl<T, R>>
+    implements _$$ReferenceImplCopyWith<T, R, $Res> {
+  __$$ReferenceImplCopyWithImpl(
+      _$ReferenceImpl<T, R> _value, $Res Function(_$ReferenceImpl<T, R>) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Reference
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? entity = freezed,
+    Object? reference = freezed,
+  }) {
+    return _then(_$ReferenceImpl<T, R>(
+      entity: freezed == entity
+          ? _value.entity
+          : entity // ignore: cast_nullable_to_non_nullable
+              as T,
+      reference: freezed == reference
+          ? _value.reference
+          : reference // ignore: cast_nullable_to_non_nullable
+              as R,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ReferenceImpl<T, R> implements _Reference<T, R> {
+  const _$ReferenceImpl({required this.entity, required this.reference});
+
+  @override
+  final T entity;
+  @override
+  final R reference;
+
+  @override
+  String toString() {
+    return 'Reference<$T, $R>(entity: $entity, reference: $reference)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReferenceImpl<T, R> &&
+            const DeepCollectionEquality().equals(other.entity, entity) &&
+            const DeepCollectionEquality().equals(other.reference, reference));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(entity),
+      const DeepCollectionEquality().hash(reference));
+
+  /// Create a copy of Reference
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReferenceImplCopyWith<T, R, _$ReferenceImpl<T, R>> get copyWith =>
+      __$$ReferenceImplCopyWithImpl<T, R, _$ReferenceImpl<T, R>>(
+          this, _$identity);
+}
+
+abstract class _Reference<T, R> implements Reference<T, R> {
+  const factory _Reference(
+      {required final T entity,
+      required final R reference}) = _$ReferenceImpl<T, R>;
+
+  @override
+  T get entity;
+  @override
+  R get reference;
+
+  /// Create a copy of Reference
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ReferenceImplCopyWith<T, R, _$ReferenceImpl<T, R>> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/application/lib/shared/dto/reference_iterable.dart
+++ b/application/lib/shared/dto/reference_iterable.dart
@@ -1,0 +1,38 @@
+import 'package:application_new/shared/dto/reference.dart';
+
+final class ReferenceIterable<T, R> {
+  final Iterable<Reference<T, R>> references;
+
+  const ReferenceIterable({Iterable<Reference<T, R>>? references})
+      : references = references ?? const [];
+
+  bool contains(T entity) {
+    final Iterable<T> entities = mapToEntity();
+    return entities.contains(entity);
+  }
+
+  ReferenceIterable<T, R> add(T entity, R reference) {
+    return ReferenceIterable(references: List.of(references)
+      ..add(Reference(entity: entity, reference: reference)));
+  }
+
+  ReferenceIterable<T, R> remove(T entity) {
+    return ReferenceIterable(references:
+        references.where((reference) => reference.entity != entity));
+  }
+
+  Iterable<T> mapToEntity() {
+    return references.map((reference) => reference.entity);
+  }
+
+  Iterable<R> mapToReference() {
+    return references.map((reference) => reference.reference).toSet();
+  }
+
+  Reference<T, R> get(int index) {
+    return references.toList()[index];
+  }
+
+  int get length => references.length;
+
+}

--- a/application/pubspec.lock
+++ b/application/pubspec.lock
@@ -54,6 +54,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
+  badges:
+    dependency: "direct main"
+    description:
+      name: badges
+      sha256: a7b6bbd60dce418df0db3058b53f9d083c22cdb5132a052145dc267494df0b84
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   boolean_selector:
     dependency: transitive
     description:

--- a/application/pubspec.yaml
+++ b/application/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
   timeago: ^3.7.0
   flutter_map_geojson: ^1.0.8
   smooth_page_indicator: ^1.2.0+3
+  badges: ^3.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> Ex. close #이슈 번호, #이슈 번호

#8 

<br/>

## 📝 작업 내용
> 작업한 내용을 간략히 설명해 주세요.

1. **선택한 도시 모달 시트에 표시하기**
   1. 선택 개수 및 선택 목록 표시하는 버튼, 위젯 UI
   2. 도시 선택 시 버튼 애니메이션 부여, 모달 시트 표시

2. **선택된 도시 클릭 시 해당되는 지도 뷰로 이동**
   1. 다른 지역 및 선택되지 않은 경우 해당 지도 뷰로 이동
   2. 지도 뷰 하단 버튼을 활성(`Active`) 상태로 변경

3. **애플리케이션 오류 수정**
    1. 계획 선택 시 위, 아래로 드래그가 안되는 문제 수정

<br/>

## ✅ 작업 결과
> 작업 내용 Notion 링크, 혹은 이미지를 첨부해 주세요.



![Simulator Screen Recording - iPhone 15 Pro Max - 2024-12-20 at 20 07 59](https://github.com/user-attachments/assets/9fa1da1a-97ea-464f-9862-9ef195c7d74d)

<br/>


## 💬 추가 사항 (선택)
> 추가로 기재할 사항이 있으면 기재해 주세요.



### 하위 프로바이더의 초기 상태를 지정하는 법

지역(시, 도) 선택 뷰 하위에 도시 선택 뷰를 자식으로 가지고 있다. 부모(지역 선택 뷰)가 자식(도시 선택 뷰)의 상태를 알맞게 변경하는 법은 무엇일까?



```dart
... () async {
  ref.read(childProvider.notifier).edit(...);
}
```

자식 선택 뷰의 `Notifier`를 직접 호출해 변경한다.

- Riverpod 프로바이더는 구독자가 없으면 자동으로 해제(Dispose)되는게 기본값이다.
- 즉, 자식 선택 뷰가 렌더링되기 전에 프로바이더가 해제되어 상태가 초기화된다.



```dart
ProviderSubscription? subscription;
subscription = ref.listenMaunal(childProvider, (prev, next) {

  ...
  ref.read(childProvider.notifier).edit(...);
  subscription?.close();
});
```

위처럼 수동으로 자식 프로바이더를 구독 및 해제할 수 있다.

- 자식의 상태를 추적해 로딩이 끝난 경우를 기다릴 수 있다.
- 다만, 자식 프로바이더의 생명 주기를 예측하기 힘들고, 이에 따라 문제가 발생할 수 있다.

자식 뷰에 초기 상태 값을 속성으로 보낸다.

- 위처럼 프로바이더 생명 주기 문제는 없지만, 구현이 복잡하고 실수할 여지가 많다.



```dart
extension CacheForExtension on AutoDisposeRef {
  /// Keeps the provider alive for [duration].
  void cacheFor(Duration duration) {

    // Immediately prevent the state from getting destroyed.
    final link = keepAlive();
    // After duration has elapsed, we re-enable automatic disposal.
    final timer = Timer(duration, link.close);

    // Optional: when the provider is recomputed (such as with ref.watch),
    // we cancel the pending timer.
    onDispose(timer.cancel);
  }
}
```

이 경우, Riverpod의 프로바이더 캐시 기능을 사용하는 것이 좋다. 자식 프로바이더를 특정 시간동안 유지(`KeepAlive`)하는 것이다.

- 해당 뷰가 재사용될 여지가 있다면, 캐시하는 것이 상태를 유지할 수 있어 유리하다.
  - 예를 들면, 충청북도의 청주를 선택하고 뒤로 나갔다 돌아와도 청주가 선택되어 있다.



```dart
@riverpod
class ProvinceCitySelect extends _$ProvinceCitySelect {
  @override
  ProvinceCitySelectState build() {
    ref.onDispose(() {
      ref.invalidate(geographySelectProvider);
    });

    return const ProvinceCitySelectState();
  }
  ...
}
```

캐시한 프로바이더를 사용하는 경우, 동작이 끝나면 적절히 `invalidate` 시켜주는 것이 좋다.