### PR TITLE
Improve(#11): 관광지 추천 시 생성자, 참여자 기준 추가

### DIFF
--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel/controller/TravelController.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel/controller/TravelController.java
@@ -36,7 +36,8 @@ public class TravelController {
     @PostMapping
     @Authorization
     public ServerResponse<TravelAndCityListDto> create(
-            @RequestBody @Valid CreateTravelRequest request) {
+            @RequestBody @Valid CreateTravelRequest request,
+            AuthenticationContext context) {
 
         final Locale locale = LocaleContextHolder.getLocale();
 
@@ -47,7 +48,8 @@ public class TravelController {
                 request.endedOn(),
                 request.motivationTypes(),
                 request.companionTypes(),
-                request.cityIds());
+                request.cityIds(),
+                context.uuid());
 
         final TravelDto travelDto = travelService.findById(createdId);
         final List<GeographyDto> cityDtoList = travelCityService.findCities(createdId);

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel/service/TravelService.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel/service/TravelService.java
@@ -3,6 +3,8 @@ package com.yeohaeng_ttukttak.server.application.travel.service;
 import com.yeohaeng_ttukttak.server.common.exception.exception.fail.EntityNotFoundFailException;
 import com.yeohaeng_ttukttak.server.domain.geography.entity.City;
 import com.yeohaeng_ttukttak.server.domain.geography.repository.GeographyRepository;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Member;
+import com.yeohaeng_ttukttak.server.domain.member.service.MemberService;
 import com.yeohaeng_ttukttak.server.domain.shared.entity.CompanionType;
 import com.yeohaeng_ttukttak.server.domain.shared.entity.MotivationType;
 import com.yeohaeng_ttukttak.server.domain.travel.dto.TravelDto;
@@ -29,6 +31,8 @@ public class TravelService {
 
     private final GeographyRepository geographyRepository;
 
+    private final MemberService memberService;
+
     /**
      * 새로운 여행을 생성합니다.
      * @param locale 현재 요청의 로케일 정보
@@ -47,7 +51,10 @@ public class TravelService {
             LocalDate endedOn,
             List<MotivationType> motivationTypes,
             List<CompanionType> companionTypes,
-            List<Long> cityIds) {
+            List<Long> cityIds,
+            String creatorId) {
+
+        final Member creator = memberService.find(creatorId);
 
         final List<City> cities = geographyRepository.findCitiesByIds(cityIds);
 
@@ -58,7 +65,7 @@ public class TravelService {
         final TravelDates dates = new TravelDates(startedOn, endedOn);
 
         final Travel travel = new Travel(
-                dates, cities, companionTypes, motivationTypes);
+               creator, dates, cities, companionTypes, motivationTypes);
 
         travelNameService.initializeName(locale, travel, inputName);
 

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city_attraction/TravelCityAttractionController.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city_attraction/TravelCityAttractionController.java
@@ -42,7 +42,7 @@ public class TravelCityAttractionController {
 
         Travel travel = travelRepository.findById(travelId).get();
 
-        Geography city = geographyRepository.findById(cityId).get();
+        City city = geographyRepository.findCityById(cityId).get();
 
         repository.recommend(travel, city);
 

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city_attraction/TravelCityAttractionController.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city_attraction/TravelCityAttractionController.java
@@ -1,0 +1,51 @@
+package com.yeohaeng_ttukttak.server.application.travel_city_attraction;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.MathExpressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yeohaeng_ttukttak.server.domain.geography.entity.City;
+import com.yeohaeng_ttukttak.server.domain.geography.entity.Geography;
+import com.yeohaeng_ttukttak.server.domain.geography.repository.GeographyRepository;
+import com.yeohaeng_ttukttak.server.domain.place.entity.Place;
+import com.yeohaeng_ttukttak.server.domain.travel.entity.Travel;
+import com.yeohaeng_ttukttak.server.domain.travel.repository.TravelRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.yeohaeng_ttukttak.server.domain.place.entity.QPlace.place;
+import static com.yeohaeng_ttukttak.server.domain.travelogue.entity.QTravelogue.travelogue;
+import static com.yeohaeng_ttukttak.server.domain.travelogue.entity.QTravelogueVisit.travelogueVisit;
+
+@RestController
+@RequestMapping("/api/v2/travels/{travelId}/cities/{cityId}/attractions")
+@RequiredArgsConstructor
+public class TravelCityAttractionController {
+
+    private final TravelRepository travelRepository;
+    private final GeographyRepository geographyRepository;
+    private final TravelCityAttractionRepository repository;
+
+    @GetMapping
+    public void recommend(
+            @PathVariable Long travelId,
+            @PathVariable Long cityId) {
+
+        Travel travel = travelRepository.findById(travelId).get();
+
+        Geography city = geographyRepository.findById(cityId).get();
+
+        repository.recommend(travel, city);
+
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city_attraction/TravelCityAttractionRepository.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city_attraction/TravelCityAttractionRepository.java
@@ -1,0 +1,125 @@
+package com.yeohaeng_ttukttak.server.application.travel_city_attraction;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.*;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yeohaeng_ttukttak.server.domain.geography.entity.Geography;
+import com.yeohaeng_ttukttak.server.domain.place.entity.Place;
+import com.yeohaeng_ttukttak.server.domain.travel.entity.Travel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.yeohaeng_ttukttak.server.domain.place.entity.QPlace.place;
+import static com.yeohaeng_ttukttak.server.domain.travelogue.entity.QTravelogue.travelogue;
+import static com.yeohaeng_ttukttak.server.domain.travelogue.entity.QTravelogueVisit.travelogueVisit;
+@Repository
+@Slf4j
+@RequiredArgsConstructor
+public class TravelCityAttractionRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 여행 선호도와 지리적 데이터를 기반으로 명소를 추천합니다.
+     *
+     * @param travel 사용자의 여행 선호도.
+     * @param geography 추천을 위한 지리적 제약.
+     */
+    public void recommend(Travel travel, Geography geography) {
+        final NumberExpression<Double> cosineSimilarity = calculateCosineSimilarity(travel);
+
+        List<Tuple> result = queryFactory.select(place, cosineSimilarity)
+                .from(place)
+                .join(place.visits, travelogueVisit)
+                .join(travelogueVisit.travelogue, travelogue)
+                .where(isInGeography(geography))
+                .orderBy(cosineSimilarity.desc())
+                .limit(10)
+                .fetch();
+
+        for (Tuple tuple : result) {
+            System.out.println("name=" + tuple.get(0, Place.class).name() + " similarity=" + tuple.get(1, Double.class));
+        }
+    }
+
+    /**
+     * <p>
+     * 여행기와 사용자 여행의 코사인 유사도를 계산합니다.
+     * <pre>
+     * Cosine Similarity = (A · B) / (||A|| * ||B||)
+     * </pre>
+     *
+     * @param travel 사용자의 여행 선호도.
+     * @return 코사인 유사도를 나타내는 NumberExpression.
+     */
+    private NumberExpression<Double> calculateCosineSimilarity(Travel travel) {
+        NumberExpression<Double> dotProduct = calculateDotProduct(travel);
+        NumberExpression<Double> magnitude = calculateDMagnitude(travel);
+
+        return dotProduct.divide(magnitude);
+    }
+
+    /**
+     * <p>
+     * 통계 벡터의 내적을 계산합니다.
+     * <pre>
+     * A · B = (A1 * B1) + (A2 * B2)
+     * </pre>
+     *
+     * @param travel 사용자의 여행 선호도.
+     * @return 내적을 나타내는 NumberExpression.
+     */
+    private NumberExpression<Double> calculateDotProduct(Travel travel) {
+        return travelogue.statistics.ageGroupAvg.multiply(travel.statistics().ageGroupAvg())
+                .add(travelogue.statistics.genderAvg.multiply(travel.statistics().genderAvg()));
+    }
+
+    /**
+     * <p>
+     * 통계 벡터의 크기를 계산합니다.
+     * <pre>
+     * ||A|| = sqrt(A1^2 + A2^2)
+     * ||B|| = sqrt(B1^2 + B2^2)
+     * </pre>
+     *
+     * @param travel 사용자의 여행 선호도.
+     * @return 크기를 나타내는 NumberExpression.
+     */
+    private NumberExpression<Double> calculateDMagnitude(Travel travel) {
+        NumberExpression<Double> leftHand = add(
+                sqrt(squared(travelogue.statistics.genderAvg)),
+                sqrt(squared(travelogue.statistics.ageGroupAvg)));
+
+        NumberExpression<Double> rightHand = add(
+                sqrt(squared(travel.statistics().genderAvg())),
+                sqrt(squared(travel.statistics().ageGroupAvg())));
+
+        return multiply(leftHand, rightHand);
+    }
+
+    /**
+     * 지정된 지역 내에 장소가 있는지 확인합니다.
+     */
+    private BooleanExpression isInGeography(Geography geography) {
+        return place.regionCode.between(geography.codeStart(), geography.codeEnd());
+    }
+
+    private NumberExpression<Double> squared(Object argument) {
+        return Expressions.numberTemplate(Double.class, "POWER({0}, 2)", argument);
+    }
+
+    private NumberExpression<Double> sqrt(Object argument) {
+        return Expressions.numberTemplate(Double.class, "SQRT({0})", argument);
+    }
+
+    private NumberExpression<Double> add(Object left, Object right) {
+        return Expressions.numberTemplate(Double.class, "({0} + {1})", left, right);
+    }
+
+    private NumberExpression<Double> multiply(Object left, Object right) {
+        return Expressions.numberTemplate(Double.class, "({0} * {1})", left, right);
+    }
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/shared/entity/ParticipantStatistics.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/shared/entity/ParticipantStatistics.java
@@ -1,0 +1,84 @@
+package com.yeohaeng_ttukttak.server.domain.shared.entity;
+
+import com.yeohaeng_ttukttak.server.domain.member.entity.AgeGroup;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Gender;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Member;
+import com.yeohaeng_ttukttak.server.domain.travel.entity.TravelParticipant;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.stream.Collectors.averagingDouble;
+
+@ToString
+@EqualsAndHashCode
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ParticipantStatistics {
+
+    private Double ageGroupAvg = 0.0;
+
+    private Double genderAvg = 0.0;
+
+    public ParticipantStatistics(Member creator, List<TravelParticipant> participants) {
+        update(creator, participants);
+    }
+
+    public void update(Member creator, List<TravelParticipant> participants) {
+        final List<Member> members = new ArrayList<>(participants
+                .stream().map(TravelParticipant::invitee)
+                .filter(this::hasStatistics)
+                .toList());
+
+        if (hasStatistics(creator)) {
+            members.add(creator);
+        }
+
+        this.ageGroupAvg = members.stream()
+                .map(Member::ageGroup)
+                .collect(averagingDouble(this::oneHotEncodeAgeGroup));
+
+        this.genderAvg = members.stream()
+                .map(Member::gender)
+                .collect(averagingDouble(this::oneHotEncodeGender));
+
+    }
+
+    private boolean hasStatistics(Member member) {
+        return Objects.nonNull(member.gender()) && Objects.nonNull(member.ageGroup());
+    }
+
+    private int oneHotEncodeGender(Gender gender) {
+        return switch (gender) {
+            case male -> 1;
+            case female -> 0;
+        };
+    }
+
+    private double oneHotEncodeAgeGroup(AgeGroup ageGroup) {
+        return switch (ageGroup) {
+            case underNine -> 0.125;
+            case teens -> 0.25;
+            case twenties -> 0.375;
+            case thirties -> 0.5;
+            case forties -> 0.625;
+            case fifties -> 0.75;
+            case sixties -> 0.875;
+            case seventiesPlus -> 1.0;
+        };
+    }
+
+    public Double ageGroupAvg() {
+        return ageGroupAvg;
+    }
+
+    public Double genderAvg() {
+        return genderAvg;
+    }
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travelogue/entity/Travelogue.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travelogue/entity/Travelogue.java
@@ -2,6 +2,7 @@ package com.yeohaeng_ttukttak.server.domain.travelogue.entity;
 
 import com.yeohaeng_ttukttak.server.domain.member.entity.AgeGroup;
 import com.yeohaeng_ttukttak.server.domain.member.entity.Gender;
+import com.yeohaeng_ttukttak.server.domain.shared.entity.ParticipantStatistics;
 import jakarta.persistence.*;
 
 import java.time.LocalDate;
@@ -17,6 +18,9 @@ public class Travelogue {
     private LocalDate startedOn;
 
     private LocalDate endedOn;
+
+    @Embedded
+    private ParticipantStatistics statistics;
 
     @Enumerated(EnumType.STRING)
     private AgeGroup ageGroup;

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travelogue/entity/TravelogueCity.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travelogue/entity/TravelogueCity.java
@@ -1,0 +1,20 @@
+package com.yeohaeng_ttukttak.server.domain.travelogue.entity;
+
+import com.yeohaeng_ttukttak.server.domain.geography.entity.City;
+import jakarta.persistence.*;
+
+@Entity
+public class TravelogueCity {
+
+    @Id
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "travelogue_id")
+    private Travelogue travelogue;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "city_id")
+    private City city;
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travelogue/entity/TravelogueParticipant.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travelogue/entity/TravelogueParticipant.java
@@ -1,0 +1,34 @@
+package com.yeohaeng_ttukttak.server.domain.travelogue.entity;
+
+import com.yeohaeng_ttukttak.server.domain.member.entity.AgeGroup;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Gender;
+import com.yeohaeng_ttukttak.server.domain.shared.entity.CompanionType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TravelogueParticipant {
+
+    @Id
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "travelogue_id")
+    private Travelogue travelogue;
+
+    @Enumerated(EnumType.STRING)
+    private CompanionType type;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    private AgeGroup ageGroup;
+
+    public Long id() {
+        return id;
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Ex. close #이슈 번호, #이슈 번호




## 📝 작업 내용

> 작업한 내용을 간략히 설명해 주세요.



#### **새로운 관광지 추천 API 설계**

- [x] REST 관점으로 API **엔드포인트 변경**
  - **변경 전:**  `GET /places/recommedations?cityId={city_id}&category=...` 
  - **변경 후:** `GET /travels/{travel_id}/cities/{city_id}/attraction` 
- [x] 추천에 필요한 **데이터 전달 방식을 변경**
  - **변경 전:** 쿼리 파라미터로 여행 동기, 동반 타입, 도시, 카테고리 등을 전달
  - **변경 후:** 계층 구조 URI으로 여행 및 도시만 지정, 내부에서 정보 조회



#### 관광지 추천 알고리즘 개선

- [x] 기준에 각 여행의 참여자의 성별, 연령대를 추가
- [x] **유클리드 유사도 기법**을 활용해 **여행 참여자**의 유사도 계산
  - [x] 사용자의 연령대, 성별 값을 일반화(Normalize) 수행
  - [x] 여행기의 연령대, 성별 평균을 표현하는  `TravelogueStatstics` 구현
  - [x] 사용자 여행의 연령대, 성별 평균을 표현하는 `TravelStatstics` 구현
    - 여행 참여자 변경 시 평균을 업데이트 하도록 구현
- [x] **베이지안 평균 기법**으로 여행 참여자 유사도 평균 값 산출
  - [x] 베이지안 평균 계수 `C` , 전체 평균 `m` 을 지정하는 레파지토리 코드 구현




## ✅ 작업 결과

> 작업 내용 Notion 링크, 혹은 이미지를 첨부해 주세요.



### 유클리도 유사도 기법으로 산출된 추천 목록

#### 20대 여성 5명

```
name=쇼킹 similarity=0.0
name=롯데리아 청주터미널점 similarity=0.0
name=냥체국 similarity=0.0
name=파스쿠찌 대청댐 similarity=0.0
name=밥보다맛있는 떡볶이방이얌 송절점 similarity=0.0
name=르뽀미에청주율량점 similarity=0.0
name=동부창고 34동 similarity=0.0
name=운리단길 similarity=0.0
name=홈버드 similarity=0.0
name=육이 similarity=0.0
```

- 여행 통계의 평균 값을 `ageGroupAvg=0.375, genderAvg=0.0`으로 설정
- 분식집, 문화시설, 카페 등이 주류를 이루는 것을 볼 수 있음



#### 50~60대 여성 다수, 남성 한명

```
name=향기나무 similarity=0.01749999999999996
name=마가레뜨 similarity=0.04500000000000004
name=콩가내 similarity=0.04500000000000004
name=김칠복커피 similarity=0.04500000000000004
name=스시명월명월 similarity=0.04500000000000004
name=두꺼비 생태공원 similarity=0.04500000000000004
name=용화사 similarity=0.07999999999999996
name=느루밥집 similarity=0.07999999999999996
name=영풍문고 청주점 similarity=0.07999999999999996
name=청주대학교 석우문화체육관 similarity=0.07999999999999996
```

- 여행 통계의 평균 값을 `ageGroupAvg=0.8, genderAvg=0.1`으로 설정
- 자연 관광지, 서점, 한식집 등이 주류를 이루는 것을 볼 수 있음



#### 10~30대 남성 3명, 여성 2명

```
name=벨리노호텔 similarity=0.044876373826076635
name=청주랜드 관리사업소 어린이회관 similarity=0.044876373826076635
name=특별횟집 similarity=0.044876373826076635
name=청주랜드 similarity=0.044876373826076635
name=홈플러스 오창점 similarity=0.044876373826076635
name=아리랑양꼬치 similarity=0.044876373826076635
name=청주가로수도서관 similarity=0.044876373826076635
name=오늘밀키친 similarity=0.048591266076208485
name=홈플러스 동청주점 similarity=0.048591266076208485
name=학봉오리 similarity=0.048591266076208485
```

- 여행 통계의 평균 값을 `ageGroupAvg=0.27, genderAvg=0.6`으로 설정
- 위 두 경우와 달리 추천된 관광지를 특정할 수 없음
  - 향후 동반 타입 유사도 가중치를 고려할 필요가 있음




## 💬 추가 사항 (선택)

> 추가로 기재할 사항이 있으면 기재해 주세요.



### 사용자 유사도 측정 방식 설계하기

#### 비교할 속성을 벡터로 변환하기

유사도 측정 기법은 각도나 거리 기반과 관계없이 평면 또는 입체 좌표에서 벡터들의 비교로 이루어진다. 따라서 비교할 값을 적절한 차원의 벡터로 변환해야 한다.

사용자마다 연령대와 성별을 비교할 때, 이 정보는 2차원 벡터로 표현된다. 각 벡터의 구성 요소는 다음과 같다:

- X축: 사용자의 성별 값을 원-핫 인코딩으로 나타낸다. (`male=1, female=0`)
- Y축: 연령대를 0부터 1까지의 값으로 일반화한 값이다.

현재 `1700개`의 여행기가 있으며, 평균적으로 `4명`의 참여자가 있다. 이를 단순화하기 위해 연령대 및 성별의 평균 값을 미리 산출한다.



기존 여행기의 데이터는 다음과 같이 변경했다.

- `TravelogueCompanion`을 `TravelogueParticipant`로 변경하고, `ageGroup`을 추가한다.
- `type`의 중복을 제거한 데이터를 `TravelogueCompanion`으로 변경한다.



#### 리 기반 vs 각도 기반 기법 비교하기

![img](https://blog.kakaocdn.net/dn/W2dk8/btqAmtn4p1k/ggR5cKZ4Dt1eXBXoc4KebK/img.png)

유사도 알고리즘은 크게 거리 기반과 각도 기반으로 나뉜다.

- **거리 기반 알고리즘**: 두 벡터 간의 거리를 측정하여 유사도를 판단한다.
- **각도 기반 알고리즘**: 두 벡터 간의 각도를 계산하여 유사도를 판단한다.

각도 기반 알고리즘을 처음 접하므로, 간단히 구현해 결과를 확인해봐야 한다.



##### 2.1 코사인 유사도 기법 구현하기

가장 간단하고 대중적인 코사인 유사도 알고리즘을 사용할 것이다.

1. 현재 여행 A와 여행기 B의 Y축 및 Z축의 평균을 구해 단일 벡터로 변환한다.
   - 데이터베이스에서 계산을 효율적으로 수행하기 위해 미리 산출한 값을 저장하는 것이 좋다.
   - 이 경우, 산출된 평균 값을 사용하므로 데이터를 2차원으로 줄일 수 있다.
2. 두 벡터 A와 B의 코사인 유사도를 산출한다.



코사인 유사도 알고리즘은 다음과 같은 공식을 따른다:

![{\displaystyle {\text{similarity}}=\cos(\theta )={A\cdot B \over \|A\|\|B\|}={\frac {\sum \limits _{i=1}^{n}{A_{i}\times B_{i}}}{{\sqrt {\sum \limits _{i=1}^{n}{(A_{i})^{2}}}}\times {\sqrt {\sum \limits _{i=1}^{n}{(B_{i})^{2}}}}}}}](https://wikimedia.org/api/rest_v1/media/math/render/svg/2a8c50526e2cc7aa837477be87eff1ea703f9dec)

- 두 벡터 ( A )와 ( B )가 존재하고, 각각 { ( a_1, a_2 ) }와 { ( b_1, b_2 ) }를 가진다고 가정한다.
- 두 벡터의 내적과 크기는 다음과 같다:
  - **벡터의 내적**: 두 벡터의 원소를 각각 곱하고 더한 값이다.
    $(a_1 \times b_1) + (a_2 \times b_2)$
  - **벡터의 크기**: 두 벡터 각각에 피타고라스 정리를 적용한 결과이다.
   $||A|| = \sqrt{a_1^2 + a_2^2}$

### 3. 특정 사례 분석

예를 들어, 20대 여성이 떠난 경우 다음과 같은 추천 결과가 도출된다:

```text
name=카페203 similarity=1.0
name=황제산삼곰탕삼계탕 similarity=1.0
name=보강천미루나무숲 similarity=1.0
name=블랙스톤벨포레리조트 similarity=1.0
name=벨포레 브리스킷346 similarity=1.0
name=블랙스톤벨포레리조트 마리나클럽 similarity=1.0
name=블랙스톤벨포레리조트 익스트림루지 similarity=1.0
name=남도예담인벨포레 similarity=1.0
name=투썸플레이스 블랙스톤벨포레점 similarity=1.0
```

카페203 방문 데이터를 살펴보니, 60대 여성들이 방문한 경우밖에 없다. 그런데 어째서 유사도가 `1.0`일까? 

- 20대 여성 벡터는 `{ 0.325, 0.0 }`이고, 60대 여성의 벡터는 `{ 0.625, 0.0 }` 이다.
- 두 벡터의 거리 차이는 크지만, 둘 다 수평 축에 위치하므로 각도는 같다. 그러므로 유사도는 `1.0`이다.



위처럼 코사인 유사도는 여행지 추천 알고리즘을 반영하기에는 한계가 있다. 각도 추천 알고리즘에서 한 축만 일치하더라도 다른 축의 값은 무시되기 때문이다.



적어도 각 값을 0부터 1까지 일반화하여 계산하는 방식에는 적용하기 어렵다. 따라서 거리 기반 기법을 사용하는 것이 보다 적합하다고 판단된다.