### PR TITLE
Improve(#11): 추천 시 관광지별 방문 이유 및 평점 추가, 예외 및 AuditorAware 동작 개선

### DIFF
--- a/application/lib/core/scroll/infinite_scroll_model.dart
+++ b/application/lib/core/scroll/infinite_scroll_model.dart
@@ -1,0 +1,42 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'infinite_scroll_model.freezed.dart';
+part 'infinite_scroll_model.g.dart';
+
+@Freezed(genericArgumentFactories: true)
+class InfiniteScrollModel<T> with _$InfiniteScrollModel<T> {
+
+  const factory InfiniteScrollModel({
+    required List<T> records,
+    @JsonKey(name: '_metadata')
+    required InfiniteScrollMetadata metadata,
+  }) = _InfiniteScrollModel;
+
+  factory InfiniteScrollModel.fromJson(
+          Map<String, dynamic> json, T Function(Object? json) fromJsonT) =>
+      _$InfiniteScrollModelFromJson(json, fromJsonT);
+
+
+  static int resolveNextPageNumber(List<InfiniteScrollModel> infiniteScrolls) {
+    if (infiniteScrolls.isEmpty) return 0;
+    return infiniteScrolls.last.metadata.pageNumber + 1;
+  }
+
+  static bool resolveHasNext(List<InfiniteScrollModel> infiniteScrolls) {
+    if (infiniteScrolls.isEmpty) return true;
+    return infiniteScrolls.last.metadata.hasNext;
+  }
+}
+
+@freezed
+class InfiniteScrollMetadata with _$InfiniteScrollMetadata {
+
+  const factory InfiniteScrollMetadata({
+    required int pageNumber,
+    required int pageSize,
+    required bool hasNext,
+  }) = _InfiniteScrollMetadata;
+
+  factory InfiniteScrollMetadata.fromJson(Map<String, dynamic> json) =>
+      _$InfiniteScrollMetadataFromJson(json);
+}

--- a/application/lib/feature/travel/travel_city_page.dart
+++ b/application/lib/feature/travel/travel_city_page.dart
@@ -1,0 +1,45 @@
+import 'package:application_new/feature/travel_city_attraction/travel_city_attraction_view.dart';
+import 'package:application_new/feature/travel_plan/provider/travel_plan_provider.dart';
+import 'package:application_new/feature/travel_plan/provider/travel_plan_state.dart';
+import 'package:application_new/shared/component/content_top_app_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class TravelCityPage extends ConsumerWidget {
+  final TravelPlanState state;
+  final TravelPlanProvider provider;
+
+  const TravelCityPage(
+      {super.key, required this.state, required this.provider});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final TravelPlanState(:cities, :selectedCity) = state;
+
+    return Scaffold(
+      appBar: AppBar(),
+      body: Column(
+        children: [
+          ContentTopAppBar(
+              child: SingleChildScrollView(
+            child: Row(children: [
+              const SizedBox(width: 24.0),
+              for (final city in cities) ...[
+                FilterChip(
+                    onSelected: (_) =>
+                        ref.read(provider.notifier).selectCity(city),
+                    label: Text(city.shortName),
+                    selected: city == selectedCity),
+                const SizedBox(width: 8.0),
+              ],
+              const SizedBox(width: 24.0),
+            ]),
+          )),
+          Expanded(
+              child: TravelCityAttractionView(
+                  travelId: provider.travelId, cityId: selectedCity.id)),
+        ],
+      ),
+    );
+  }
+}

--- a/application/lib/feature/travel_city_attraction/travel_city_attraction_provider.dart
+++ b/application/lib/feature/travel_city_attraction/travel_city_attraction_provider.dart
@@ -1,0 +1,42 @@
+import 'package:application_new/common/http/http_service.dart';
+import 'package:application_new/common/http/http_service_provider.dart';
+import 'package:application_new/common/util/riverpod_extensions.dart';
+import 'package:application_new/core/scroll/infinite_scroll_model.dart';
+import 'package:application_new/domain/place/place_model.dart';
+import 'package:application_new/feature/travel_city_attraction/travel_city_attraction_state.dart';
+import 'package:application_new/shared/dto/types.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'travel_city_attraction_provider.g.dart';
+
+@riverpod
+class TravelCityAttraction extends _$TravelCityAttraction {
+
+  static const int pageSize = 10;
+
+  @override
+  FutureOr<TravelCityAttractionState> build(int travelId, int cityId) async {
+    ref.cacheFor(const Duration(minutes: 5));
+
+    final attraction = await _fetchAttraction(0, pageSize);
+
+    return TravelCityAttractionState(attractions: [attraction]);
+  }
+
+
+  Future<InfiniteScrollModel<PlaceModel>> _fetchAttraction(
+      int pageNumber, int pageSize) async {
+
+    final Json queryParameters = {
+      'pageNumber': pageNumber,
+      'pageSize': pageSize,
+    };
+
+    final response = await ref.read(httpServiceProvider).get(
+        '/travels/$travelId/cities/$cityId/attractions',
+        options: ServerRequestOptions(queryParameters: queryParameters));
+
+    return InfiniteScrollModel.fromJson(response['places'],
+        (object) => PlaceModel.fromJson(object as Map<String, dynamic>));
+  }
+}

--- a/application/lib/feature/travel_city_attraction/travel_city_attraction_state.dart
+++ b/application/lib/feature/travel_city_attraction/travel_city_attraction_state.dart
@@ -1,0 +1,14 @@
+import 'package:application_new/core/scroll/infinite_scroll_model.dart';
+import 'package:application_new/domain/place/place_model.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'travel_city_attraction_state.freezed.dart';
+
+@freezed
+class TravelCityAttractionState with _$TravelCityAttractionState {
+
+  const factory TravelCityAttractionState({
+    required List<InfiniteScrollModel<PlaceModel>> attractions,
+  }) = _TravelCityAttractionState;
+
+}

--- a/application/lib/feature/travel_city_attraction/travel_city_attraction_view.dart
+++ b/application/lib/feature/travel_city_attraction/travel_city_attraction_view.dart
@@ -1,0 +1,52 @@
+import 'package:application_new/core/scroll/infinite_scroll_model.dart';
+import 'package:application_new/feature/travel_city_attraction/travel_city_attraction_provider.dart';
+import 'package:application_new/feature/travel_city_attraction/travel_city_attraction_state.dart';
+import 'package:application_new/shared/component/infinite_list_indicator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class TravelCityAttractionView extends ConsumerWidget {
+  final int travelId, cityId;
+
+  const TravelCityAttractionView(
+      {super.key, required this.travelId, required this.cityId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncState =
+        ref.watch(travelCityAttractionProvider(travelId, cityId));
+
+    return asyncState.when(
+      data: (state) {
+        final TravelCityAttractionState(:attractions) = state;
+
+        return CustomScrollView(slivers: [
+          SliverList.builder(
+              itemCount: attractions.length,
+              itemBuilder: (context, index) {
+                final attraction = attractions[index];
+
+                return Column(children: [
+                  for (final place in attraction.records)
+                    Column(children: [
+                      Container(width: 400, height: 320, color: Colors.blue),
+                      Text(place.name)
+                    ])
+                ]);
+              }),
+
+          SliverFillRemaining(
+            child: InfiniteListIndicator(
+                onVisible: () => print('hi'),
+                hasNextPage: InfiniteScrollModel.resolveHasNext(attractions)),
+          )
+        ]);
+      },
+      error: (error, stack) {
+        print(stack);
+        throw error;
+      },
+      loading: () => const Center(child: CircularProgressIndicator()),
+    );
+  }
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/auth/service/OAuthLoginService.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/auth/service/OAuthLoginService.java
@@ -50,11 +50,7 @@ public class OAuthLoginService {
 
         log.debug("[OAuthLoginService.login] member = {}", member);
 
-        final AuthenticationContext authorization = new AuthenticationContext(
-                member.uuid(),
-                member.nickname(),
-                member.ageGroup(),
-                member.gender());
+        final AuthenticationContext authorization = AuthenticationContext.of(member);
 
         final String accessToken = accessTokenService.create(authorization);
         final String refreshToken = refreshTokenService.create(member.uuid());

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/auth/service/RenewAuthService.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/auth/service/RenewAuthService.java
@@ -29,11 +29,7 @@ public class RenewAuthService {
         refreshTokenService.revoke(verifiedToken);
 
         final Member member = memberService.find(memberId);
-        final AuthenticationContext authorization = new AuthenticationContext(
-                member.uuid(),
-                member.nickname(),
-                member.ageGroup(),
-                member.gender());
+        final AuthenticationContext authorization = AuthenticationContext.of(member);
 
         return new AuthTokenDto(
                 accessTokenService.create(authorization),

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city/TravelCityController.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city/TravelCityController.java
@@ -1,6 +1,7 @@
 package com.yeohaeng_ttukttak.server.application.travel_city;
 
 import com.yeohaeng_ttukttak.server.application.travel.service.TravelService;
+import com.yeohaeng_ttukttak.server.application.travel_city.dto.CityListResponse;
 import com.yeohaeng_ttukttak.server.domain.travel.dto.TravelAndCityListDto;
 import com.yeohaeng_ttukttak.server.common.aop.annotation.Authorization;
 import com.yeohaeng_ttukttak.server.common.dto.ServerResponse;
@@ -8,10 +9,7 @@ import com.yeohaeng_ttukttak.server.domain.auth.dto.AuthenticationContext;
 import com.yeohaeng_ttukttak.server.domain.geography.dto.GeographyDto;
 import com.yeohaeng_ttukttak.server.domain.travel.dto.TravelDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Locale;
@@ -35,11 +33,17 @@ public class TravelCityController {
         travelCityService.addCity(locale, context.uuid(), travelId, cityId);
 
         final List<GeographyDto> cityDtoList = travelCityService.findCities(travelId);
-
         final TravelDto travelDto = travelService.findById(travelId);
 
-
         return new ServerResponse<>(new TravelAndCityListDto(travelDto, cityDtoList));
+    }
+
+    @GetMapping
+    public ServerResponse<CityListResponse> findCities(@PathVariable Long travelId) {
+        final List<GeographyDto> cityDtoList =
+                travelCityService.findCities(travelId);
+
+        return new ServerResponse<>(new CityListResponse(cityDtoList));
     }
 
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city/dto/CityListResponse.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city/dto/CityListResponse.java
@@ -1,0 +1,8 @@
+package com.yeohaeng_ttukttak.server.application.travel_city.dto;
+
+import com.yeohaeng_ttukttak.server.domain.geography.dto.GeographyDto;
+
+import java.util.List;
+
+public record CityListResponse(
+        List<GeographyDto> cities) { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city_attraction/AttractionQueryDto.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city_attraction/AttractionQueryDto.java
@@ -1,0 +1,16 @@
+package com.yeohaeng_ttukttak.server.application.travel_city_attraction;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.yeohaeng_ttukttak.server.domain.place.entity.Place;
+import com.yeohaeng_ttukttak.server.domain.travel_city_attraction.AttractionDto;
+
+public record AttractionQueryDto(Place place, Double rating) {
+
+    @QueryProjection
+    public AttractionQueryDto {}
+
+    public AttractionDto toEntityDto() {
+        return AttractionDto.of(place, rating);
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city_attraction/TravelCityAttractionController.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city_attraction/TravelCityAttractionController.java
@@ -1,6 +1,6 @@
 package com.yeohaeng_ttukttak.server.application.travel_city_attraction;
 
-import com.yeohaeng_ttukttak.server.application.travel_city_attraction.dto.PlaceInfiniteScrolledResponse;
+import com.yeohaeng_ttukttak.server.application.travel_city_attraction.dto.AttractionInfiniteScrolledResponse;
 import com.yeohaeng_ttukttak.server.common.dto.InfiniteScrollCommand;
 import com.yeohaeng_ttukttak.server.common.dto.InfiniteScrollResult;
 import com.yeohaeng_ttukttak.server.common.dto.ServerResponse;
@@ -10,6 +10,7 @@ import com.yeohaeng_ttukttak.server.domain.geography.repository.GeographyReposit
 import com.yeohaeng_ttukttak.server.domain.place.dto.PlaceDto;
 import com.yeohaeng_ttukttak.server.domain.travel.entity.Travel;
 import com.yeohaeng_ttukttak.server.domain.travel.repository.TravelRepository;
+import com.yeohaeng_ttukttak.server.domain.travel_city_attraction.AttractionDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,7 +28,7 @@ public class TravelCityAttractionController {
 
     @GetMapping
     @Transactional(readOnly = true)
-    public ServerResponse<PlaceInfiniteScrolledResponse> orderByTravelSimilarity(
+    public ServerResponse<AttractionInfiniteScrolledResponse> orderByTravelSimilarity(
             @PathVariable Long travelId, @PathVariable Long cityId, @ModelAttribute InfiniteScrollCommand scrollCommand) {
 
         final Travel travel = travelRepository.findById(travelId)
@@ -36,10 +37,10 @@ public class TravelCityAttractionController {
         final City city = geographyRepository.findCityById(cityId)
                 .orElseThrow(() -> new EntityNotFoundFailException(City.class));
 
-        final InfiniteScrollResult<PlaceDto> scrollResult =
+        final InfiniteScrollResult<AttractionDto> scrollResult =
                 repository.orderByTravelSimilarity(scrollCommand, travel, city);
 
-        return new ServerResponse<>(new PlaceInfiniteScrolledResponse(scrollResult));
+        return new ServerResponse<>(new AttractionInfiniteScrolledResponse(scrollResult));
     }
 
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city_attraction/dto/AttractionInfiniteScrolledResponse.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city_attraction/dto/AttractionInfiniteScrolledResponse.java
@@ -1,0 +1,7 @@
+package com.yeohaeng_ttukttak.server.application.travel_city_attraction.dto;
+
+import com.yeohaeng_ttukttak.server.common.dto.InfiniteScrollResult;
+import com.yeohaeng_ttukttak.server.domain.travel_city_attraction.AttractionDto;
+
+public record AttractionInfiniteScrolledResponse(
+        InfiniteScrollResult<AttractionDto> attractions) { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city_attraction/dto/PlaceInfiniteScrolledResponse.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/application/travel_city_attraction/dto/PlaceInfiniteScrolledResponse.java
@@ -1,8 +1,0 @@
-package com.yeohaeng_ttukttak.server.application.travel_city_attraction.dto;
-
-import com.yeohaeng_ttukttak.server.common.dto.InfiniteScrollResult;
-import com.yeohaeng_ttukttak.server.domain.place.dto.PlaceDto;
-
-public record PlaceInfiniteScrolledResponse (
-        InfiniteScrollResult<PlaceDto> places
-) { }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/aop/AopConfig.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/aop/AopConfig.java
@@ -1,10 +1,12 @@
 package com.yeohaeng_ttukttak.server.common.aop;
 
 import com.yeohaeng_ttukttak.server.domain.auth.service.AccessTokenService;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Member;
 import com.yeohaeng_ttukttak.server.domain.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 
 @Configuration
 public class AopConfig {
@@ -18,8 +20,7 @@ public class AopConfig {
     }
 
     @Bean
-    public MemberAuditorAware memberAuditorAware(
-            MemberRepository memberRepository) {
+    public AuditorAware<Member> memberAuditorAware(MemberRepository memberRepository) {
         return new MemberAuditorAware(memberRepository);
     }
 

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/aop/AuthenticationContextHolder.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/aop/AuthenticationContextHolder.java
@@ -6,6 +6,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AuthenticationContextHolder {
 
+    private AuthenticationContextHolder() {}
+
     private static final ThreadLocal<AuthenticationContext> contextHolder = new ThreadLocal<>();
 
     public static void setContext(AuthenticationContext context) {

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/aop/MemberAuditorAware.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/aop/MemberAuditorAware.java
@@ -1,13 +1,22 @@
 package com.yeohaeng_ttukttak.server.common.aop;
 
+import com.yeohaeng_ttukttak.server.common.exception.exception.fail.AuthorizationFailException;
 import com.yeohaeng_ttukttak.server.domain.auth.dto.AuthenticationContext;
 import com.yeohaeng_ttukttak.server.domain.member.entity.Member;
 import com.yeohaeng_ttukttak.server.domain.member.repository.MemberRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Session;
+import org.hibernate.engine.spi.EntityEntry;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -21,7 +30,17 @@ public class MemberAuditorAware implements AuditorAware<Member> {
         final AuthenticationContext context =
                 AuthenticationContextHolder.getContext();
 
-        return memberRepository.findByUuid(context.uuid());
+        final Member member = context.member()
+                .orElseGet(() -> {
+                    final Member foundMember = memberRepository.findByUuid(context.uuid())
+                            .orElseThrow(AuthorizationFailException::new);
+
+                    AuthenticationContextHolder.setContext(AuthenticationContext.of(foundMember));
+
+                    return foundMember;
+                });
+
+        return Optional.of(member);
     }
 
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/dto/JpaInfiniteScrollResult.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/dto/JpaInfiniteScrollResult.java
@@ -2,7 +2,7 @@ package com.yeohaeng_ttukttak.server.common.dto;
 
 
 import com.querydsl.jpa.impl.JPAQuery;
-import com.yeohaeng_ttukttak.server.common.exception.exception.fail.PageNotFoundFailException;
+import com.yeohaeng_ttukttak.server.common.exception.exception.fail.EntityNotFoundFailException;
 
 import java.util.List;
 import java.util.function.Function;
@@ -21,7 +21,7 @@ public final class JpaInfiniteScrollResult<T, R> implements InfiniteScrollResult
                 .fetch();
 
         if (entities.isEmpty()) {
-            throw new PageNotFoundFailException();
+            throw new EntityNotFoundFailException("Page");
         }
 
         final boolean hasNext = entities.size() > command.pageSize();

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/serializer/DoublePrecisionSerializer.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/serializer/DoublePrecisionSerializer.java
@@ -1,0 +1,16 @@
+package com.yeohaeng_ttukttak.server.common.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+public final class DoublePrecisionSerializer extends JsonSerializer<Double>  {
+
+    @Override
+    public void serialize(Double value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeNumber(String.format("%.2f", value));
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/common/serializer/SerializationConfig.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/common/serializer/SerializationConfig.java
@@ -1,0 +1,19 @@
+package com.yeohaeng_ttukttak.server.common.serializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SerializationConfig {
+
+    @Autowired
+    public void doublePrecisionSerializer(ObjectMapper objectMapper) {
+        final SimpleModule module = new SimpleModule();
+        module.addSerializer(Double.class, new DoublePrecisionSerializer());
+
+        objectMapper.registerModule(module);
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/auth/dto/AuthenticationContext.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/auth/dto/AuthenticationContext.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public record AuthenticationContext(Optional<Member> member, String uuid) {
 
     public Map<String, Object> toClaims() {
-        return new HashMap<>(Map.of("sub", uuid, "nickname", nickname));
+        return new HashMap<>(Map.of("sub", uuid));
     }
 
 

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/auth/dto/AuthenticationContext.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/auth/dto/AuthenticationContext.java
@@ -1,89 +1,32 @@
 package com.yeohaeng_ttukttak.server.domain.auth.dto;
 
-import com.yeohaeng_ttukttak.server.common.util.EnumUtil;
 import com.yeohaeng_ttukttak.server.domain.jwt.dto.JwtClaim;
-import com.yeohaeng_ttukttak.server.domain.member.entity.AgeGroup;
-import com.yeohaeng_ttukttak.server.domain.member.entity.Gender;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import com.yeohaeng_ttukttak.server.domain.member.entity.Member;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 
 /**
  * 사용자의 인증 정보를 표현하는 DTO
  */
-@ToString
-@EqualsAndHashCode
-public class AuthenticationContext {
-    private final String uuid;
-    private final String nickname;
-    private final AgeGroup ageGroup;
-    private final Gender gender;
-
-    /**
-     * @param uuid     사용자의 식별자
-     * @param nickname 사용자 닉네임
-     * @param ageGroup 사용자의 연령대
-     * @param gender   사용자의 성별
-     */
-    public AuthenticationContext(
-            String uuid,
-            String nickname,
-            AgeGroup ageGroup,
-            Gender gender) {
-        this.uuid = uuid;
-        this.nickname = nickname;
-        this.ageGroup = ageGroup;
-        this.gender = gender;
-    }
+public record AuthenticationContext(Optional<Member> member, String uuid) {
 
     public Map<String, Object> toClaims() {
-        final Map<String, Object> claims = new HashMap<>(Map.of("sub", uuid));
+        return new HashMap<>(Map.of("sub", uuid, "nickname", nickname));
+    }
 
-        if (Objects.nonNull(ageGroup)) {
-            claims.put("age_group", ageGroup.toString());
-        }
 
-        if (Objects.nonNull(nickname)) {
-            claims.put("nickname", nickname);
-        }
-
-        if (Objects.nonNull(gender)) {
-            claims.put("gender", gender.toString());
-        }
-
-        return claims;
+    public static AuthenticationContext of(Member member) {
+        return new AuthenticationContext(Optional.ofNullable(member), member.uuid());
     }
 
     public static AuthenticationContext fromClaims(Map<String, JwtClaim> claims) {
 
-        final String ageGroup = JwtClaim.of(claims, "age_group").asString();
-        final String gender = JwtClaim.of(claims, "gender").asString();
-
         return new AuthenticationContext(
-                JwtClaim.of(claims, "sub").asString(),
-                JwtClaim.of(claims, "nickname").asString(),
-                EnumUtil.fromStringOrNull(AgeGroup.class, ageGroup),
-                EnumUtil.fromStringOrNull(Gender.class, gender)
-        );
+                Optional.empty(),
+                JwtClaim.of(claims, "sub").asString());
     }
 
-    public String uuid() {
-        return uuid;
-    }
-
-    public String nickname() {
-        return nickname;
-    }
-
-    public AgeGroup ageGroup() {
-        return ageGroup;
-    }
-
-    public Gender gender() {
-        return gender;
-    }
 
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/Member.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/entity/Member.java
@@ -55,7 +55,7 @@ public class Member {
         this.avatar = new DefaultAvatar(this);
     }
 
-    Long id() { return id; }
+    public Long id() { return id; }
 
     public String uuid() {
         return uuid;

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/member/repository/MemberRepository.java
@@ -8,9 +8,10 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    @Query("SELECT u FROM Member u WHERE u.auth.openId = :openId")
+    @Query("SELECT m FROM Member m WHERE m.auth.openId = :openId")
     Optional<Member> findByOpenId(String openId);
 
+    @Query("SELECT m FROM Member m WHERE m.uuid = :uuid")
     Optional<Member> findByUuid(String uuid);
 
 }

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel_city_attraction/AttractionDto.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel_city_attraction/AttractionDto.java
@@ -1,0 +1,57 @@
+package com.yeohaeng_ttukttak.server.domain.travel_city_attraction;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.yeohaeng_ttukttak.server.domain.place.entity.Place;
+import com.yeohaeng_ttukttak.server.domain.place.entity.PlaceCategory;
+import com.yeohaeng_ttukttak.server.domain.place.entity.PlaceCategoryType;
+import com.yeohaeng_ttukttak.server.domain.shared.entity.VisitReasonType;
+import com.yeohaeng_ttukttak.server.domain.travelogue.entity.TravelogueVisit;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import static java.util.Comparator.comparingLong;
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
+
+public record AttractionDto(
+        Long id,
+        String name,
+        String roadAddress,
+        String lotNumberAddress,
+        List<PlaceCategoryType> categoryTypes,
+        List<AttractionVisitReasonDto> visitReasons
+) {
+
+    public record AttractionVisitReasonDto(
+            VisitReasonType reasonType, Long count) {
+
+        public static AttractionVisitReasonDto of (Entry<VisitReasonType, Long> entry) {
+            return new AttractionVisitReasonDto(entry.getKey(), entry.getValue());
+        }
+
+    }
+
+    public static AttractionDto of(Place place) {
+        final List<AttractionVisitReasonDto> visitReasons = place.visits().stream()
+                .collect(groupingBy(TravelogueVisit::reasonType, counting()))
+                .entrySet()
+                .stream().map(AttractionVisitReasonDto::of)
+                .sorted(comparingLong(AttractionVisitReasonDto::count).reversed())
+                .toList();
+
+        return new AttractionDto(place.id(),
+            place.name(),
+            place.roadAddress(),
+            place.lotNumberAddress(),
+            place.categories().stream()
+                    .map(PlaceCategory::type).distinct().toList(),
+                visitReasons
+        );
+    }
+
+}

--- a/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel_city_attraction/AttractionDto.java
+++ b/server/src/main/java/com/yeohaeng_ttukttak/server/domain/travel_city_attraction/AttractionDto.java
@@ -1,18 +1,13 @@
 package com.yeohaeng_ttukttak.server.domain.travel_city_attraction;
 
-import com.querydsl.core.annotations.QueryProjection;
 import com.yeohaeng_ttukttak.server.domain.place.entity.Place;
 import com.yeohaeng_ttukttak.server.domain.place.entity.PlaceCategory;
 import com.yeohaeng_ttukttak.server.domain.place.entity.PlaceCategoryType;
 import com.yeohaeng_ttukttak.server.domain.shared.entity.VisitReasonType;
 import com.yeohaeng_ttukttak.server.domain.travelogue.entity.TravelogueVisit;
 
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 import static java.util.Comparator.comparingLong;
 import static java.util.stream.Collectors.counting;
@@ -23,6 +18,7 @@ public record AttractionDto(
         String name,
         String roadAddress,
         String lotNumberAddress,
+        Double rating,
         List<PlaceCategoryType> categoryTypes,
         List<AttractionVisitReasonDto> visitReasons
 ) {
@@ -36,7 +32,7 @@ public record AttractionDto(
 
     }
 
-    public static AttractionDto of(Place place) {
+    public static AttractionDto of(Place place, Double satisfaction) {
         final List<AttractionVisitReasonDto> visitReasons = place.visits().stream()
                 .collect(groupingBy(TravelogueVisit::reasonType, counting()))
                 .entrySet()
@@ -48,6 +44,7 @@ public record AttractionDto(
             place.name(),
             place.roadAddress(),
             place.lotNumberAddress(),
+            satisfaction,
             place.categories().stream()
                     .map(PlaceCategory::type).distinct().toList(),
                 visitReasons


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Ex. close #이슈 번호, #이슈 번호



#11




## 📝 작업 내용

> 작업한 내용을 간략히 설명해 주세요.


- [x] 서버 예외(Exception) 로거 개선

  - 발생한 `Exception` 의 `cause` 가 없을 때까지 출력하게끔 개선
- [x] `AudtiorAware` 동작 개선

  - 찾은 `Member` 엔티티를 캐시해 I/O 블로킹 타임을 최적화
- [x] 관광지 추천 기능 고도화&오류 해결

  - 관광지별 방문 이유 및 평점 정보 집계 

  - 전체 평균을 집계하는 쿼리에 그룹 기준이 누락된 것을 보완




## ✅ 작업 결과

> 작업 내용 Notion 링크, 혹은 이미지를 첨부해 주세요.



<img width="976" alt="image" src="https://github.com/user-attachments/assets/e9c0956a-b3c4-4054-b13e-4c6ee610da02" />




## 💬 추가 사항 (선택)

> 추가로 기재할 사항이 있으면 기재해 주세요.



### 실수 데이터 포맷팅 방법

<img width="976" alt="image" src="https://github.com/user-attachments/assets/0ef5c424-2abb-4506-8ec5-5f63423c1825" />

실수 데이터는 위처럼 긴 자리수를 가지고 있다. 이를 2자리로 줄이기 위해서 아래와 같은 방법을 적용할 수 있다.

1. `BigDecimal` 를 활용해 두자리 실수 데이터로 변환한다.
2. 두 자리 이하를 자르는 `JsonDeserializer` 를 구현해, 등록한다.



```java
// Cache of common small BigDecimal values.
    private static final BigDecimal ZERO_THROUGH_TEN[] = {
        new BigDecimal(BigInteger.ZERO,       0,  0, 1),
      	...
        new BigDecimal(BigInteger.valueOf(9), 9,  0, 1),
        new BigDecimal(BigInteger.TEN,        10, 0, 2),
    };

    // Cache of zero scaled by 0 - 15
    private static final BigDecimal[] ZERO_SCALED_BY = {
        ZERO_THROUGH_TEN[0],
        new BigDecimal(BigInteger.ZERO, 0, 1, 1),
      	...
        new BigDecimal(BigInteger.ZERO, 0, 15, 1),
    };
```

구현하기는 (1)번 방법이 쉽지만 성능 이슈가 있다. `BigDecimal`은 부동소수점으로 표현된 실수를 정확하게 표현하는데 중점을 맞췄기 때문이다. 이 때문에 위처럼 사전에 캐시된 정적 값들이 존재한다. 하지만, 내가 표현하려는 평점은 해당 캐시를 사용할 수 없다는 것을 확인했다.



```java
public final class DoublePrecisionSerializer extends JsonSerializer<Double>  {
    @Override
    public void serialize(Double value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
        gen.writeNumber(String.format("%.2f", value));
    }
}

@Configuration
public class SerializationConfig {
    @Autowired
    public void doublePrecisionSerializer(ObjectMapper objectMapper) {
        final SimpleModule module = new SimpleModule();
        module.addSerializer(Double.class, new DoublePrecisionSerializer());

        objectMapper.registerModule(module);
    }
}
```

그러므로 (2) 방안을 채택했다. `JsonDeserializer<Double>` 을 구현하는 사용자 지정 역직렬화기를 만들고, Jackson 라이브러리에  `Module`로써 등록했다.
