### PR TITLE
Feature(#10): 여행 수정 UI 구현 및 API 연동

### DIFF
--- a/application/assets/translations/ko.yaml
+++ b/application/assets/translations/ko.yaml
@@ -33,6 +33,10 @@ Delete comment: 댓글 삭제하기
 
 Easy of Access: 좋은 접근성
 Edit comment: 댓글 수정하기
+Edit companion type: 동반 타입 수정
+Edit date: 날짜 수정
+Edit name: 이름 수정
+Edit motivation type: 동기 수정
 Edit profile: 프로필 수정
 Edited: 수정됨
 Education: 교육성

--- a/application/lib/common/loading/async_loading_provider.dart
+++ b/application/lib/common/loading/async_loading_provider.dart
@@ -10,7 +10,7 @@ class AsyncLoading extends _$AsyncLoading {
     return const AsyncLoadingSemaphore();
   }
 
-  FutureOr<T> guard<T>(FutureOr<T> Function() callback) async {
+  Future<T> guard<T>(FutureOr<T> Function() callback) async {
     try {
       state = state.copyWith(count: state.count + 1);
       return await callback();

--- a/application/lib/common/loading/async_loading_provider.g.dart
+++ b/application/lib/common/loading/async_loading_provider.g.dart
@@ -6,7 +6,7 @@ part of 'async_loading_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$asyncLoadingHash() => r'eb8a736df37fffe514d174f6eca9113c3270fde7';
+String _$asyncLoadingHash() => r'7f7ef80409a80d691f3b1b508acf2a68505e5345';
 
 /// See also [AsyncLoading].
 @ProviderFor(AsyncLoading)

--- a/application/lib/common/router/router_provider.dart
+++ b/application/lib/common/router/router_provider.dart
@@ -6,6 +6,7 @@ import 'package:application_new/feature/error/error_page.dart';
 import 'package:application_new/feature/home/home_page.dart';
 import 'package:application_new/feature/profile/profile_edit_page.dart';
 import 'package:application_new/feature/travel_create/page/travel_create_page.dart';
+import 'package:application_new/feature/travel_create/page/travel_form_page.dart';
 import 'package:application_new/feature/travel_invitation/page/travel_invitation_page.dart';
 import 'package:application_new/feature/travel_plan/page/travel_plan_participant/page/travel_plan_participant_page.dart';
 import 'package:application_new/feature/travel_plan/page/travel_plan_recommend/page/city_travels/page/city_travels_page.dart';

--- a/application/lib/domain/travel/travel_repository.dart
+++ b/application/lib/domain/travel/travel_repository.dart
@@ -1,0 +1,70 @@
+import 'package:application_new/common/http/http_service.dart';
+import 'package:application_new/common/http/http_service_provider.dart';
+import 'package:application_new/domain/geography/geography_model.dart';
+import 'package:application_new/domain/travel/travel_model.dart';
+import 'package:application_new/shared/dto/types.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'travel_repository.g.dart';
+
+final class TravelRepository {
+  final HttpService httpService;
+
+  TravelRepository(this.httpService);
+
+  Future<TravelModel> create({
+    required String name,
+    required DateTime startedOn,
+    required DateTime endedOn,
+    required List<TravelCompanionType> companionTypes,
+    required List<TravelMotivationType> motivationTypes,
+    required List<CityModel> cities,
+  }) async {
+    final response = await httpService.post('/travels',
+        options: ServerRequestOptions(data: {
+          'startedOn': startedOn.toIso8601String(),
+          'endedOn': endedOn.toIso8601String(),
+          'name': name,
+          'companionTypes': companionTypes.map((e) => e.name).toList(),
+          'motivationTypes': motivationTypes.map((e) => e.name).toList(),
+          'cityIds': cities.map((city) => city.id).toList(),
+        }));
+
+    return TravelModel.fromJson(response['travel']);
+  }
+
+  Future<TravelModel> update(int travelId, {
+    String? name,
+    DateTime? startedOn,
+    DateTime? endedOn,
+    List<TravelCompanionType>? companionTypes,
+    List<TravelMotivationType>? motivationTypes,
+    List<CityModel>? cities,
+  }) async {
+    final Json requestData = {};
+
+    void addIfNotNull(String key, dynamic value) {
+      if (value != null) {
+        requestData[key] = value;
+      }
+    }
+
+    addIfNotNull('name', name);
+    addIfNotNull('startedOn', startedOn);
+    addIfNotNull('endedOn', endedOn);
+    addIfNotNull('companionTypes', companionTypes?.map((e) => e.name).toList());
+    addIfNotNull('motivationTypes', motivationTypes?.map((e) => e.name).toList());
+
+    final response = await httpService.patch('/travels/$travelId',
+        options: ServerRequestOptions(data: requestData));
+
+    return TravelModel.fromJson(response['travel']);
+  }
+
+
+}
+
+@riverpod
+TravelRepository travelRepository(TravelRepositoryRef ref) {
+  return TravelRepository(ref.watch(httpServiceProvider));
+}

--- a/application/lib/domain/travel/travel_repository.g.dart
+++ b/application/lib/domain/travel/travel_repository.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'travel_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$travelRepositoryHash() => r'5f7f2c74dbe8e2283af4ee3733d128d22c0f949b';
+
+/// See also [travelRepository].
+@ProviderFor(travelRepository)
+final travelRepositoryProvider = AutoDisposeProvider<TravelRepository>.internal(
+  travelRepository,
+  name: r'travelRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$travelRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef TravelRepositoryRef = AutoDisposeProviderRef<TravelRepository>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/application/lib/feature/travel_create/page/travel_city_form.dart
+++ b/application/lib/feature/travel_create/page/travel_city_form.dart
@@ -9,9 +9,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../provider/travel_create_provider.dart';
 
 class TravelCityForm extends ConsumerWidget {
-  final PageController pageController;
 
-  const TravelCityForm(this.pageController, {super.key});
+  final int pageIndex;
+  final PagedFormBottomControlViewBuilder bottomViewBuilder;
+
+  const TravelCityForm({super.key, required this.pageIndex, required this.bottomViewBuilder});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -20,8 +22,8 @@ class TravelCityForm extends ConsumerWidget {
     return Scaffold(
       body: ScaffoldMessenger(
         child: ProvinceCitySelectView(countryId: 0)),
-      bottomNavigationBar: PagedFormBottomControlView(
-          isInputted: cities.isNotEmpty, controller: pageController),
+      bottomNavigationBar: bottomViewBuilder(
+          isInputted: cities.isNotEmpty, pageIndex: pageIndex),
     );
   }
 }

--- a/application/lib/feature/travel_create/page/travel_companion_type_form.dart
+++ b/application/lib/feature/travel_create/page/travel_companion_type_form.dart
@@ -13,9 +13,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../provider/travel_create_provider.dart';
 
 class TravelCompanionTypeForm extends ConsumerWidget {
-  final PageController pageController;
 
-  const TravelCompanionTypeForm(this.pageController, {super.key});
+  final int pageIndex;
+  final PagedFormBottomControlViewBuilder bottomViewBuilder;
+
+  const TravelCompanionTypeForm({super.key, required this.pageIndex, required this.bottomViewBuilder});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -80,8 +82,8 @@ class TravelCompanionTypeForm extends ConsumerWidget {
                       })),
             ],
           ),
-          bottomNavigationBar: PagedFormBottomControlView(
-              isInputted: companionTypes.isNotEmpty, controller: pageController)),
+    bottomNavigationBar: bottomViewBuilder(
+    isInputted: companionTypes.isNotEmpty, pageIndex: pageIndex))
     );
   }
 }

--- a/application/lib/feature/travel_create/page/travel_date_form.dart
+++ b/application/lib/feature/travel_create/page/travel_date_form.dart
@@ -11,9 +11,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../provider/travel_create_provider.dart';
 
 class TravelDateForm extends ConsumerWidget {
-  final PageController pageController;
 
-  const TravelDateForm(this.pageController, {super.key});
+  final int pageIndex;
+  final PagedFormBottomControlViewBuilder bottomViewBuilder;
+
+  const TravelDateForm({super.key, required this.pageIndex, required this.bottomViewBuilder});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -64,9 +66,8 @@ class TravelDateForm extends ConsumerWidget {
           ),
         ],
       ),
-      bottomNavigationBar: PagedFormBottomControlView(
-        hasPreviousPage: false,
-          controller: pageController, isInputted: isDateSelected),
+      bottomNavigationBar: bottomViewBuilder(
+        isInputted: isDateSelected, pageIndex: pageIndex),
     );
   }
 

--- a/application/lib/feature/travel_create/page/travel_form_page.dart
+++ b/application/lib/feature/travel_create/page/travel_form_page.dart
@@ -16,15 +16,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../provider/travel_create_provider.dart';
 
 class TravelFormPage extends ConsumerStatefulWidget {
-
   final bool Function(TravelCreateState) canSubmit;
 
   final void Function(TravelCreateState) onSubmit;
 
   final int pageSize;
-  
-  final List<Widget>
-  Function(PagedFormBottomControlViewBuilder bottomViewBuilder) buildPages;
+
+  final List<Widget> Function(
+      PagedFormBottomControlViewBuilder bottomViewBuilder) buildPages;
 
   final TravelCreateState? initialState;
 
@@ -32,7 +31,7 @@ class TravelFormPage extends ConsumerStatefulWidget {
       {super.key,
       required this.canSubmit,
       required this.onSubmit,
-       required this.pageSize,
+      required this.pageSize,
       required this.buildPages,
       this.initialState});
 
@@ -97,8 +96,10 @@ class _CreateTravelPageState extends ConsumerState<TravelFormPage> {
 
     final canSubmit = widget.canSubmit(state);
 
-    final bottomViewBuilder = 
-    PagedFormBottomControlView.create(pageController, pageSize: widget.pageSize, canSubmit: canSubmit, onSubmit: () => widget.onSubmit(state));
+    final bottomViewBuilder = PagedFormBottomControlView.create(pageController,
+        pageSize: widget.pageSize,
+        canSubmit: canSubmit,
+        onSubmit: () => widget.onSubmit.call(state));
 
     return Scaffold(
       body: PageView(

--- a/application/lib/feature/travel_create/page/travel_form_page.dart
+++ b/application/lib/feature/travel_create/page/travel_form_page.dart
@@ -1,0 +1,110 @@
+import 'package:application_new/common/event/event.dart';
+import 'package:application_new/core/message/message_util.dart';
+import 'package:application_new/core/translation/translation_service.dart';
+import 'package:application_new/domain/travel/travel_model.dart';
+import 'package:application_new/feature/geography_select/province_city_select_provider.dart';
+import 'package:application_new/feature/travel_create/page/travel_city_form.dart';
+import 'package:application_new/feature/travel_create/page/travel_date_form.dart';
+import 'package:application_new/feature/travel_create/page/travel_companion_type_form.dart';
+import 'package:application_new/feature/travel_create/page/travel_motivation_type_form.dart';
+import 'package:application_new/feature/travel_create/page/travel_name_form.dart';
+import 'package:application_new/feature/travel_create/provider/travel_create_state.dart';
+import 'package:application_new/shared/component/paged_form_bottom_control_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../provider/travel_create_provider.dart';
+
+class TravelFormPage extends ConsumerStatefulWidget {
+
+  final bool Function(TravelCreateState) canSubmit;
+
+  final void Function(TravelCreateState) onSubmit;
+
+  final int pageSize;
+  
+  final List<Widget>
+  Function(PagedFormBottomControlViewBuilder bottomViewBuilder) buildPages;
+
+  final TravelCreateState? initialState;
+
+  const TravelFormPage(
+      {super.key,
+      required this.canSubmit,
+      required this.onSubmit,
+       required this.pageSize,
+      required this.buildPages,
+      this.initialState});
+
+  @override
+  ConsumerState createState() => _CreateTravelPageState();
+}
+
+class _CreateTravelPageState extends ConsumerState<TravelFormPage> {
+  final PageController pageController = PageController();
+
+  @override
+  void initState() {
+    Future.microtask(() {
+      final initState = widget.initialState;
+
+      if (initState == null) return;
+
+      final travelFormNotifier = ref.read(travelCreateProvider.notifier);
+
+      travelFormNotifier.enterName(initState.name);
+
+      for (final motivationType in initState.motivationTypes) {
+        travelFormNotifier.selectMotivationType(motivationType);
+      }
+
+      for (final companionType in initState.companionTypes) {
+        travelFormNotifier.selectCompanionType(companionType);
+      }
+
+      travelFormNotifier.selectCities(initState.cities);
+
+      travelFormNotifier.selectDate(initState.startedOn, initState.endedOn);
+    });
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tr = ref.watch(translationServiceProvider);
+
+    ref.listen(provinceCitySelectProvider, (prev, next) {
+      final selectedCities = next.selectedCities;
+      if (prev?.selectedCities == selectedCities) return;
+
+      if (selectedCities.length > 10) {
+        MessageUtil.showSnackBar(context,
+            MessageEvent(tr.from('You can select up to {}.', args: ['${10}'])));
+      }
+
+      final notifier = ref.read(travelCreateProvider.notifier);
+      notifier.selectCities(selectedCities.mapToEntity().toList());
+    });
+
+    final state = ref.watch(travelCreateProvider);
+
+    final canSubmit = widget.canSubmit(state);
+
+    final bottomViewBuilder = 
+    PagedFormBottomControlView.create(pageController, pageSize: widget.pageSize, canSubmit: canSubmit, onSubmit: () => widget.onSubmit(state));
+
+    return Scaffold(
+      body: PageView(
+          physics: const NeverScrollableScrollPhysics(),
+          controller: pageController,
+          children: widget.buildPages(bottomViewBuilder)),
+    );
+  }
+}

--- a/application/lib/feature/travel_create/page/travel_motivation_type_form.dart
+++ b/application/lib/feature/travel_create/page/travel_motivation_type_form.dart
@@ -13,9 +13,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../provider/travel_create_provider.dart';
 
 class TravelMotivationTypeForm extends ConsumerWidget {
-  final PageController pageController;
+  final int pageIndex;
+  final PagedFormBottomControlViewBuilder bottomViewBuilder;
 
-  const TravelMotivationTypeForm(this.pageController, {super.key});
+  const TravelMotivationTypeForm(
+      {super.key, required this.pageIndex, required this.bottomViewBuilder});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -91,9 +93,8 @@ class TravelMotivationTypeForm extends ConsumerWidget {
                       })),
             ],
           ),
-          bottomNavigationBar: PagedFormBottomControlView(
-              isInputted: motivationTypes.isNotEmpty,
-              controller: pageController)),
+          bottomNavigationBar: bottomViewBuilder(
+              isInputted: motivationTypes.isNotEmpty, pageIndex: pageIndex)),
     );
   }
 }

--- a/application/lib/feature/travel_create/page/travel_name_form.dart
+++ b/application/lib/feature/travel_create/page/travel_name_form.dart
@@ -13,17 +13,46 @@ import 'package:go_router/go_router.dart';
 
 import '../provider/travel_create_provider.dart';
 
-class TravelNameForm extends ConsumerWidget {
+class TravelNameForm extends ConsumerStatefulWidget {
   final int pageIndex;
   final PagedFormBottomControlViewBuilder bottomViewBuilder;
 
-  final TextEditingController nameController = TextEditingController();
-
-  TravelNameForm(
+  const TravelNameForm(
       {super.key, required this.pageIndex, required this.bottomViewBuilder});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState createState() => _TravelNameFormState();
+}
+
+class _TravelNameFormState extends ConsumerState<TravelNameForm> {
+  final TextEditingController nameController = TextEditingController();
+
+  final FocusNode nameFocusNode = FocusNode();
+
+  @override
+  void initState() {
+    Future.microtask(() {
+      final name = ref.read(travelCreateProvider).name;
+
+      FocusManager.instance.primaryFocus?.requestFocus(nameFocusNode);
+
+      if (name != null) {
+        nameController.text = name;
+      }
+    });
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    nameController.dispose();
+    nameFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final tr = ref.watch(translationServiceProvider);
 
     final state = ref.watch(travelCreateProvider);
@@ -37,10 +66,6 @@ class TravelNameForm extends ConsumerWidget {
         .whereType<ProvinceModel>()
         .map((province) => province.shortName)
         .join(', ');
-
-    if (name != null) {
-      nameController.text = name;
-    }
 
     return Scaffold(
       appBar: AppBar(shape: const Border()),
@@ -62,10 +87,10 @@ class TravelNameForm extends ConsumerWidget {
             padding: const EdgeInsets.symmetric(horizontal: 24.0),
             child: TextFormField(
               controller: nameController,
+              focusNode: nameFocusNode,
               onTapOutside: (_) =>
                   FocusManager.instance.primaryFocus?.unfocus(),
               onChanged: (name) {
-                if (name.isEmpty) return;
                 ref.read(travelCreateProvider.notifier).enterName(name);
               },
               decoration: InputDecoration(
@@ -91,8 +116,8 @@ class TravelNameForm extends ConsumerWidget {
           )
         ],
       ),
-      bottomNavigationBar: bottomViewBuilder(
-          isInputted: name?.isNotEmpty ?? false, pageIndex: pageIndex),
+      bottomNavigationBar: widget.bottomViewBuilder(
+          isInputted: name?.isNotEmpty ?? false, pageIndex: widget.pageIndex),
     );
   }
 }

--- a/application/lib/feature/travel_create/page/travel_name_form.dart
+++ b/application/lib/feature/travel_create/page/travel_name_form.dart
@@ -67,6 +67,9 @@ class _TravelNameFormState extends ConsumerState<TravelNameForm> {
         .map((province) => province.shortName)
         .join(', ');
 
+    final String? defaultName =
+        cities.isNotEmpty ? tr.from('Travel of {}', args: [provinceNames]) : null;
+
     return Scaffold(
       appBar: AppBar(shape: const Border()),
       body: Column(
@@ -111,13 +114,14 @@ class _TravelNameFormState extends ConsumerState<TravelNameForm> {
                         },
                         child: const Icon(Icons.clear)),
                   ),
-                  hintText: tr.from('Travel of {}', args: [provinceNames])),
+                  hintText: defaultName),
             ),
           )
         ],
       ),
       bottomNavigationBar: widget.bottomViewBuilder(
-          isInputted: name?.isNotEmpty ?? false, pageIndex: widget.pageIndex),
+          isInputted: name?.isNotEmpty ?? defaultName?.isNotEmpty ?? false,
+          pageIndex: widget.pageIndex),
     );
   }
 }

--- a/application/lib/feature/travel_create/provider/travel_create_provider.dart
+++ b/application/lib/feature/travel_create/provider/travel_create_provider.dart
@@ -1,6 +1,8 @@
 import 'package:application_new/common/http/http_service.dart';
 import 'package:application_new/common/http/http_service_provider.dart';
 import 'package:application_new/common/loading/async_loading_provider.dart';
+import 'package:application_new/core/translation/translation_service.dart';
+import 'package:application_new/domain/geography/geography_provider.dart';
 import 'package:application_new/domain/travel/travel_model.dart';
 import 'package:application_new/feature/authentication/service/auth_service_provider.dart';
 import 'package:application_new/domain/geography/geography_model.dart';
@@ -63,14 +65,13 @@ class TravelCreate extends _$TravelCreate {
   }
 
   void selectCities(List<CityModel> cities) {
-    if (cities.length > 10) return;
+    if (cities.length > 10 || cities.isEmpty) return;
+
     state = state.copyWith(cities: cities);
   }
-
 
   void setFieldErrors(Map<String, String> fieldErrors) {
     if (state.fieldErrors == fieldErrors) return;
     state = state.copyWith(fieldErrors: fieldErrors);
   }
-
 }

--- a/application/lib/feature/travel_create/provider/travel_create_provider.dart
+++ b/application/lib/feature/travel_create/provider/travel_create_provider.dart
@@ -18,6 +18,7 @@ class TravelCreate extends _$TravelCreate {
 
   void enterName(String? name) {
     if (state.name == name) return;
+    print(name);
     state = state.copyWith(name: name);
   }
 
@@ -65,14 +66,6 @@ class TravelCreate extends _$TravelCreate {
   void selectCities(List<CityModel> cities) {
     if (cities.length > 10) return;
     state = state.copyWith(cities: cities);
-  }
-
-  void selectRegion(ProvinceModel? region) {
-    if (state.region == region) return;
-
-    state = state.copyWith(
-      region: region,
-    );
   }
 
   void prevPage() {

--- a/application/lib/feature/travel_create/provider/travel_create_provider.dart
+++ b/application/lib/feature/travel_create/provider/travel_create_provider.dart
@@ -18,7 +18,6 @@ class TravelCreate extends _$TravelCreate {
 
   void enterName(String? name) {
     if (state.name == name) return;
-    print(name);
     state = state.copyWith(name: name);
   }
 
@@ -68,41 +67,6 @@ class TravelCreate extends _$TravelCreate {
     state = state.copyWith(cities: cities);
   }
 
-  void prevPage() {
-    if (state.pageNumber == 0) return;
-    state = state.copyWith(pageNumber: state.pageNumber - 1);
-  }
-
-  void nextPage() {
-    if (state.pageNumber == 2) return;
-    state = state.copyWith(pageNumber: state.pageNumber + 1);
-  }
-
-  Future<TravelModel> submit() async {
-    final TravelCreateState(
-      :name,
-      :startedOn,
-      :endedOn,
-      :companionTypes,
-      :motivationTypes,
-      :cities
-    ) = state;
-
-    final travel = await ref.read(asyncLoadingProvider.notifier).guard(() async {
-      final response = await ref.read(httpServiceProvider).post('/travels',
-          options: ServerRequestOptions(data: {
-            'startedOn': startedOn?.toIso8601String(),
-            'endedOn': endedOn?.toIso8601String(),
-            'name': name,
-            'companionTypes': companionTypes.map((e) => e.name).toList(),
-            'motivationTypes': motivationTypes.map((e) => e.name).toList(),
-            'cityIds': cities.map((city) => city.id).toList(),
-          }));
-
-      return TravelModel.fromJson(response['travel']);
-    });
-    return travel;
-  }
 
   void setFieldErrors(Map<String, String> fieldErrors) {
     if (state.fieldErrors == fieldErrors) return;

--- a/application/lib/feature/travel_create/provider/travel_create_provider.g.dart
+++ b/application/lib/feature/travel_create/provider/travel_create_provider.g.dart
@@ -6,7 +6,7 @@ part of 'travel_create_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$travelCreateHash() => r'0650541c5da1a512cdc4d8d8b6b59765fd4035d7';
+String _$travelCreateHash() => r'95c3ee0187e3cd9cf7a83c492e516af01f116753';
 
 /// See also [TravelCreate].
 @ProviderFor(TravelCreate)

--- a/application/lib/feature/travel_create/provider/travel_create_provider.g.dart
+++ b/application/lib/feature/travel_create/provider/travel_create_provider.g.dart
@@ -6,7 +6,7 @@ part of 'travel_create_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$travelCreateHash() => r'95c3ee0187e3cd9cf7a83c492e516af01f116753';
+String _$travelCreateHash() => r'd277ecdd99407ba02ef2b5674cf8f878ceffcedd';
 
 /// See also [TravelCreate].
 @ProviderFor(TravelCreate)

--- a/application/lib/feature/travel_create/provider/travel_create_provider.g.dart
+++ b/application/lib/feature/travel_create/provider/travel_create_provider.g.dart
@@ -6,7 +6,7 @@ part of 'travel_create_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$travelCreateHash() => r'd277ecdd99407ba02ef2b5674cf8f878ceffcedd';
+String _$travelCreateHash() => r'b57b770ecaf420e65da3a8ae92771a842c86b4be';
 
 /// See also [TravelCreate].
 @ProviderFor(TravelCreate)

--- a/application/lib/feature/travel_create/provider/travel_create_state.dart
+++ b/application/lib/feature/travel_create/provider/travel_create_state.dart
@@ -13,7 +13,6 @@ class TravelCreateState with _$TravelCreateState {
     DateTime? endedOn,
     @Default([]) List<TravelCompanionType> companionTypes,
     @Default([]) List<TravelMotivationType> motivationTypes,
-    ProvinceModel? region,
     @Default([]) List<CityModel> cities,
     @Default({}) Map<String, String> fieldErrors,
   }) = _TravelCreateState;

--- a/application/lib/feature/travel_create/provider/travel_create_state.dart
+++ b/application/lib/feature/travel_create/provider/travel_create_state.dart
@@ -8,7 +8,6 @@ part 'travel_create_state.freezed.dart';
 class TravelCreateState with _$TravelCreateState {
   const factory TravelCreateState({
     String? name,
-    @Default(0) int pageNumber,
     DateTime? startedOn,
     DateTime? endedOn,
     @Default([]) List<TravelCompanionType> companionTypes,

--- a/application/lib/feature/travel_create/provider/travel_create_state.freezed.dart
+++ b/application/lib/feature/travel_create/provider/travel_create_state.freezed.dart
@@ -17,7 +17,6 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$TravelCreateState {
   String? get name => throw _privateConstructorUsedError;
-  int get pageNumber => throw _privateConstructorUsedError;
   DateTime? get startedOn => throw _privateConstructorUsedError;
   DateTime? get endedOn => throw _privateConstructorUsedError;
   List<TravelCompanionType> get companionTypes =>
@@ -42,7 +41,6 @@ abstract class $TravelCreateStateCopyWith<$Res> {
   @useResult
   $Res call(
       {String? name,
-      int pageNumber,
       DateTime? startedOn,
       DateTime? endedOn,
       List<TravelCompanionType> companionTypes,
@@ -67,7 +65,6 @@ class _$TravelCreateStateCopyWithImpl<$Res, $Val extends TravelCreateState>
   @override
   $Res call({
     Object? name = freezed,
-    Object? pageNumber = null,
     Object? startedOn = freezed,
     Object? endedOn = freezed,
     Object? companionTypes = null,
@@ -80,10 +77,6 @@ class _$TravelCreateStateCopyWithImpl<$Res, $Val extends TravelCreateState>
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String?,
-      pageNumber: null == pageNumber
-          ? _value.pageNumber
-          : pageNumber // ignore: cast_nullable_to_non_nullable
-              as int,
       startedOn: freezed == startedOn
           ? _value.startedOn
           : startedOn // ignore: cast_nullable_to_non_nullable
@@ -122,7 +115,6 @@ abstract class _$$TravelCreateStateImplCopyWith<$Res>
   @useResult
   $Res call(
       {String? name,
-      int pageNumber,
       DateTime? startedOn,
       DateTime? endedOn,
       List<TravelCompanionType> companionTypes,
@@ -145,7 +137,6 @@ class __$$TravelCreateStateImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? name = freezed,
-    Object? pageNumber = null,
     Object? startedOn = freezed,
     Object? endedOn = freezed,
     Object? companionTypes = null,
@@ -158,10 +149,6 @@ class __$$TravelCreateStateImplCopyWithImpl<$Res>
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String?,
-      pageNumber: null == pageNumber
-          ? _value.pageNumber
-          : pageNumber // ignore: cast_nullable_to_non_nullable
-              as int,
       startedOn: freezed == startedOn
           ? _value.startedOn
           : startedOn // ignore: cast_nullable_to_non_nullable
@@ -195,7 +182,6 @@ class __$$TravelCreateStateImplCopyWithImpl<$Res>
 class _$TravelCreateStateImpl implements _TravelCreateState {
   const _$TravelCreateStateImpl(
       {this.name,
-      this.pageNumber = 0,
       this.startedOn,
       this.endedOn,
       final List<TravelCompanionType> companionTypes = const [],
@@ -209,9 +195,6 @@ class _$TravelCreateStateImpl implements _TravelCreateState {
 
   @override
   final String? name;
-  @override
-  @JsonKey()
-  final int pageNumber;
   @override
   final DateTime? startedOn;
   @override
@@ -254,7 +237,7 @@ class _$TravelCreateStateImpl implements _TravelCreateState {
 
   @override
   String toString() {
-    return 'TravelCreateState(name: $name, pageNumber: $pageNumber, startedOn: $startedOn, endedOn: $endedOn, companionTypes: $companionTypes, motivationTypes: $motivationTypes, cities: $cities, fieldErrors: $fieldErrors)';
+    return 'TravelCreateState(name: $name, startedOn: $startedOn, endedOn: $endedOn, companionTypes: $companionTypes, motivationTypes: $motivationTypes, cities: $cities, fieldErrors: $fieldErrors)';
   }
 
   @override
@@ -263,8 +246,6 @@ class _$TravelCreateStateImpl implements _TravelCreateState {
         (other.runtimeType == runtimeType &&
             other is _$TravelCreateStateImpl &&
             (identical(other.name, name) || other.name == name) &&
-            (identical(other.pageNumber, pageNumber) ||
-                other.pageNumber == pageNumber) &&
             (identical(other.startedOn, startedOn) ||
                 other.startedOn == startedOn) &&
             (identical(other.endedOn, endedOn) || other.endedOn == endedOn) &&
@@ -281,7 +262,6 @@ class _$TravelCreateStateImpl implements _TravelCreateState {
   int get hashCode => Object.hash(
       runtimeType,
       name,
-      pageNumber,
       startedOn,
       endedOn,
       const DeepCollectionEquality().hash(_companionTypes),
@@ -302,7 +282,6 @@ class _$TravelCreateStateImpl implements _TravelCreateState {
 abstract class _TravelCreateState implements TravelCreateState {
   const factory _TravelCreateState(
       {final String? name,
-      final int pageNumber,
       final DateTime? startedOn,
       final DateTime? endedOn,
       final List<TravelCompanionType> companionTypes,
@@ -312,8 +291,6 @@ abstract class _TravelCreateState implements TravelCreateState {
 
   @override
   String? get name;
-  @override
-  int get pageNumber;
   @override
   DateTime? get startedOn;
   @override

--- a/application/lib/feature/travel_create/provider/travel_create_state.freezed.dart
+++ b/application/lib/feature/travel_create/provider/travel_create_state.freezed.dart
@@ -24,7 +24,6 @@ mixin _$TravelCreateState {
       throw _privateConstructorUsedError;
   List<TravelMotivationType> get motivationTypes =>
       throw _privateConstructorUsedError;
-  ProvinceModel? get region => throw _privateConstructorUsedError;
   List<CityModel> get cities => throw _privateConstructorUsedError;
   Map<String, String> get fieldErrors => throw _privateConstructorUsedError;
 
@@ -48,7 +47,6 @@ abstract class $TravelCreateStateCopyWith<$Res> {
       DateTime? endedOn,
       List<TravelCompanionType> companionTypes,
       List<TravelMotivationType> motivationTypes,
-      ProvinceModel? region,
       List<CityModel> cities,
       Map<String, String> fieldErrors});
 }
@@ -74,7 +72,6 @@ class _$TravelCreateStateCopyWithImpl<$Res, $Val extends TravelCreateState>
     Object? endedOn = freezed,
     Object? companionTypes = null,
     Object? motivationTypes = null,
-    Object? region = freezed,
     Object? cities = null,
     Object? fieldErrors = null,
   }) {
@@ -103,10 +100,6 @@ class _$TravelCreateStateCopyWithImpl<$Res, $Val extends TravelCreateState>
           ? _value.motivationTypes
           : motivationTypes // ignore: cast_nullable_to_non_nullable
               as List<TravelMotivationType>,
-      region: freezed == region
-          ? _value.region
-          : region // ignore: cast_nullable_to_non_nullable
-              as ProvinceModel?,
       cities: null == cities
           ? _value.cities
           : cities // ignore: cast_nullable_to_non_nullable
@@ -134,7 +127,6 @@ abstract class _$$TravelCreateStateImplCopyWith<$Res>
       DateTime? endedOn,
       List<TravelCompanionType> companionTypes,
       List<TravelMotivationType> motivationTypes,
-      ProvinceModel? region,
       List<CityModel> cities,
       Map<String, String> fieldErrors});
 }
@@ -158,7 +150,6 @@ class __$$TravelCreateStateImplCopyWithImpl<$Res>
     Object? endedOn = freezed,
     Object? companionTypes = null,
     Object? motivationTypes = null,
-    Object? region = freezed,
     Object? cities = null,
     Object? fieldErrors = null,
   }) {
@@ -187,10 +178,6 @@ class __$$TravelCreateStateImplCopyWithImpl<$Res>
           ? _value._motivationTypes
           : motivationTypes // ignore: cast_nullable_to_non_nullable
               as List<TravelMotivationType>,
-      region: freezed == region
-          ? _value.region
-          : region // ignore: cast_nullable_to_non_nullable
-              as ProvinceModel?,
       cities: null == cities
           ? _value._cities
           : cities // ignore: cast_nullable_to_non_nullable
@@ -213,7 +200,6 @@ class _$TravelCreateStateImpl implements _TravelCreateState {
       this.endedOn,
       final List<TravelCompanionType> companionTypes = const [],
       final List<TravelMotivationType> motivationTypes = const [],
-      this.region,
       final List<CityModel> cities = const [],
       final Map<String, String> fieldErrors = const {}})
       : _companionTypes = companionTypes,
@@ -248,8 +234,6 @@ class _$TravelCreateStateImpl implements _TravelCreateState {
     return EqualUnmodifiableListView(_motivationTypes);
   }
 
-  @override
-  final ProvinceModel? region;
   final List<CityModel> _cities;
   @override
   @JsonKey()
@@ -270,7 +254,7 @@ class _$TravelCreateStateImpl implements _TravelCreateState {
 
   @override
   String toString() {
-    return 'TravelCreateState(name: $name, pageNumber: $pageNumber, startedOn: $startedOn, endedOn: $endedOn, companionTypes: $companionTypes, motivationTypes: $motivationTypes, region: $region, cities: $cities, fieldErrors: $fieldErrors)';
+    return 'TravelCreateState(name: $name, pageNumber: $pageNumber, startedOn: $startedOn, endedOn: $endedOn, companionTypes: $companionTypes, motivationTypes: $motivationTypes, cities: $cities, fieldErrors: $fieldErrors)';
   }
 
   @override
@@ -288,7 +272,6 @@ class _$TravelCreateStateImpl implements _TravelCreateState {
                 .equals(other._companionTypes, _companionTypes) &&
             const DeepCollectionEquality()
                 .equals(other._motivationTypes, _motivationTypes) &&
-            const DeepCollectionEquality().equals(other.region, region) &&
             const DeepCollectionEquality().equals(other._cities, _cities) &&
             const DeepCollectionEquality()
                 .equals(other._fieldErrors, _fieldErrors));
@@ -303,7 +286,6 @@ class _$TravelCreateStateImpl implements _TravelCreateState {
       endedOn,
       const DeepCollectionEquality().hash(_companionTypes),
       const DeepCollectionEquality().hash(_motivationTypes),
-      const DeepCollectionEquality().hash(region),
       const DeepCollectionEquality().hash(_cities),
       const DeepCollectionEquality().hash(_fieldErrors));
 
@@ -325,7 +307,6 @@ abstract class _TravelCreateState implements TravelCreateState {
       final DateTime? endedOn,
       final List<TravelCompanionType> companionTypes,
       final List<TravelMotivationType> motivationTypes,
-      final ProvinceModel? region,
       final List<CityModel> cities,
       final Map<String, String> fieldErrors}) = _$TravelCreateStateImpl;
 
@@ -341,8 +322,6 @@ abstract class _TravelCreateState implements TravelCreateState {
   List<TravelCompanionType> get companionTypes;
   @override
   List<TravelMotivationType> get motivationTypes;
-  @override
-  ProvinceModel? get region;
   @override
   List<CityModel> get cities;
   @override

--- a/application/lib/feature/travel_plan/page/travel_plan_home_page.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_home_page.dart
@@ -1,7 +1,10 @@
 import 'package:application_new/common/util/translation_util.dart';
 import 'package:application_new/core/translation/translation_service.dart';
 import 'package:application_new/domain/member/member_provider.dart';
+import 'package:application_new/feature/travel_create/page/travel_companion_type_form.dart';
+import 'package:application_new/feature/travel_create/page/travel_date_form.dart';
 import 'package:application_new/feature/travel_create/page/travel_form_page.dart';
+import 'package:application_new/feature/travel_create/page/travel_motivation_type_form.dart';
 import 'package:application_new/feature/travel_create/page/travel_name_form.dart';
 import 'package:application_new/feature/travel_create/provider/travel_create_provider.dart';
 import 'package:application_new/feature/travel_create/provider/travel_create_state.dart';
@@ -11,6 +14,7 @@ import 'package:application_new/feature/travel_plan/provider/travel_plan_state.d
 import 'package:application_new/shared/component/action_sheet.dart';
 import 'package:application_new/shared/component/action_sheet_item.dart';
 import 'package:application_new/shared/component/show_modal_content_sheet.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -40,6 +44,88 @@ class _TravelPlanHomePageState extends ConsumerState<TravelPlanHomePage> {
 
     const headerStyle = TextStyle(fontSize: 20.0, fontWeight: FontWeight.w600);
     final owner = ref.watch(memberProvider(travel.memberId)).value;
+
+    final editNameAction = ActionSheetItem(
+      title: ref.watch(translationServiceProvider).from('Edit name'),
+      onAction: () => showModalContentSheet(
+        showDragHandle: false,
+        context,
+        TravelFormPage(
+          initialState: TravelCreateState(name: travel.name),
+          canSubmit: (state) => travel.name != state.name,
+          onSubmit: (state) {
+            print(state.name);
+          },
+          pageSize: 1,
+          buildPages: (bottomViewBuilder) => [
+            TravelNameForm(pageIndex: 0, bottomViewBuilder: bottomViewBuilder)
+          ],
+        ),
+      ),
+    );
+
+    final editDateAction = ActionSheetItem(
+      title: ref.watch(translationServiceProvider).from('Edit date'),
+      onAction: () => showModalContentSheet(
+        showDragHandle: false,
+        context,
+        TravelFormPage(
+          initialState: TravelCreateState(
+              startedOn: travel.startedOn, endedOn: travel.endedOn),
+          canSubmit: (state) => state.startedOn != travel.startedOn &&
+                state.endedOn != travel.endedOn,
+          onSubmit: (state) {
+            print(state);
+          },
+          pageSize: 1,
+          buildPages: (bottomViewBuilder) => [
+            TravelDateForm(pageIndex: 0, bottomViewBuilder: bottomViewBuilder)
+          ],
+        ),
+      ),
+    );
+
+    final editCompanionTypeAction = ActionSheetItem(
+      title: ref.watch(translationServiceProvider).from('Edit companion type'),
+      onAction: () => showModalContentSheet(
+        showDragHandle: false,
+        context,
+        TravelFormPage(
+          initialState: TravelCreateState(
+              companionTypes: travel.companionTypes),
+          canSubmit: (state) => !listEquals(state.companionTypes, travel.companionTypes),
+          onSubmit: (state) {
+            print(state);
+          },
+          pageSize: 1,
+          buildPages: (bottomViewBuilder) => [
+            TravelCompanionTypeForm(pageIndex: 0, bottomViewBuilder: bottomViewBuilder)
+          ],
+        ),
+      ),
+    );
+
+
+    final editMotivationTypeAction = ActionSheetItem(
+      title: ref.watch(translationServiceProvider).from('Edit motivation type'),
+      onAction: () => showModalContentSheet(
+        showDragHandle: false,
+        context,
+        TravelFormPage(
+          initialState: TravelCreateState(
+              motivationTypes: travel.motivationTypes),
+          canSubmit: (state) => !setEquals(state.motivationTypes.toSet(),
+              travel.motivationTypes.toSet()),
+          onSubmit: (state) {
+            print(state);
+          },
+          pageSize: 1,
+          buildPages: (bottomViewBuilder) => [
+            TravelMotivationTypeForm(pageIndex: 0, bottomViewBuilder: bottomViewBuilder)
+          ],
+        ),
+      ),
+    );
 
     return IntrinsicSizeBuilder(
         firstFrameWidget: Container(
@@ -94,41 +180,10 @@ class _TravelPlanHomePageState extends ConsumerState<TravelPlanHomePage> {
                             ActionSheet.show(
                               context,
                               items: [
-                                ActionSheetItem(
-                                  title: ref
-                                      .watch(translationServiceProvider)
-                                      .from('Edit name'),
-                                  onAction: () async {
-                                    await showModalContentSheet(
-                                      showDragHandle: false,
-                                      context,
-                                      TravelFormPage(
-                                        initialState: TravelCreateState(name: travel.name),
-                                        canSubmit: (state) => state.name != null && travel.name != state.name,
-                                        onSubmit: (state) {
-                                          print(state.name);
-                                        },
-                                        pageSize: 1,
-                                        buildPages: (bottomViewBuilder) => [TravelNameForm(pageIndex: 0, bottomViewBuilder: bottomViewBuilder)],
-                                      ),
-                                    );
-                                  },
-                                ),
-                                ActionSheetItem(
-                                    title: ref
-                                        .watch(translationServiceProvider)
-                                        .from('Edit date'),
-                                    onAction: () {}),
-                                ActionSheetItem(
-                                    title: ref
-                                        .watch(translationServiceProvider)
-                                        .from('Edit companion type'),
-                                    onAction: () {}),
-                                ActionSheetItem(
-                                    title: ref
-                                        .watch(translationServiceProvider)
-                                        .from('Edit motivation type'),
-                                    onAction: () {}),
+                                editNameAction,
+                                editDateAction,
+                                editCompanionTypeAction,
+                                editMotivationTypeAction,
                               ],
                             );
                           },

--- a/application/lib/feature/travel_plan/page/travel_plan_home_page.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_home_page.dart
@@ -1,8 +1,16 @@
 import 'package:application_new/common/util/translation_util.dart';
+import 'package:application_new/core/translation/translation_service.dart';
 import 'package:application_new/domain/member/member_provider.dart';
+import 'package:application_new/feature/travel_create/page/travel_form_page.dart';
+import 'package:application_new/feature/travel_create/page/travel_name_form.dart';
+import 'package:application_new/feature/travel_create/provider/travel_create_provider.dart';
+import 'package:application_new/feature/travel_create/provider/travel_create_state.dart';
 import 'package:application_new/feature/travel_plan/component/travel_info_chip.dart';
 import 'package:application_new/feature/travel_plan/provider/travel_plan_provider.dart';
 import 'package:application_new/feature/travel_plan/provider/travel_plan_state.dart';
+import 'package:application_new/shared/component/action_sheet.dart';
+import 'package:application_new/shared/component/action_sheet_item.dart';
+import 'package:application_new/shared/component/show_modal_content_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -61,9 +69,6 @@ class _TravelPlanHomePageState extends ConsumerState<TravelPlanHomePage> {
                       label: travel.companionTypes
                           .map((e) => TranslationUtil.enumValue(e))
                           .join(', ')),
-                  // TravelInfoChip(
-                  //     avatar: Icons.place,
-                  //     label: travel.cities.map((e) => e.name).join(', ')),
                   TravelInfoChip(
                       avatar: Icons.tag,
                       label: travel.motivationTypes
@@ -85,7 +90,48 @@ class _TravelPlanHomePageState extends ConsumerState<TravelPlanHomePage> {
                     pinned: true,
                     actions: [
                       IconButton(
-                          onPressed: () {},
+                          onPressed: () {
+                            ActionSheet.show(
+                              context,
+                              items: [
+                                ActionSheetItem(
+                                  title: ref
+                                      .watch(translationServiceProvider)
+                                      .from('Edit name'),
+                                  onAction: () async {
+                                    await showModalContentSheet(
+                                      showDragHandle: false,
+                                      context,
+                                      TravelFormPage(
+                                        initialState: TravelCreateState(name: travel.name),
+                                        canSubmit: (state) => state.name != null && travel.name != state.name,
+                                        onSubmit: (state) {
+                                          print(state.name);
+                                        },
+                                        pageSize: 1,
+                                        buildPages: (bottomViewBuilder) => [TravelNameForm(pageIndex: 0, bottomViewBuilder: bottomViewBuilder)],
+                                      ),
+                                    );
+                                  },
+                                ),
+                                ActionSheetItem(
+                                    title: ref
+                                        .watch(translationServiceProvider)
+                                        .from('Edit date'),
+                                    onAction: () {}),
+                                ActionSheetItem(
+                                    title: ref
+                                        .watch(translationServiceProvider)
+                                        .from('Edit companion type'),
+                                    onAction: () {}),
+                                ActionSheetItem(
+                                    title: ref
+                                        .watch(translationServiceProvider)
+                                        .from('Edit motivation type'),
+                                    onAction: () {}),
+                              ],
+                            );
+                          },
                           icon: const Icon(Icons.edit_note_outlined)),
                       Padding(
                         padding: const EdgeInsets.only(right: 16.0),

--- a/application/lib/feature/travel_plan/page/travel_plan_home_page.dart
+++ b/application/lib/feature/travel_plan/page/travel_plan_home_page.dart
@@ -1,6 +1,8 @@
+import 'package:application_new/common/loading/async_loading_provider.dart';
 import 'package:application_new/common/util/translation_util.dart';
 import 'package:application_new/core/translation/translation_service.dart';
 import 'package:application_new/domain/member/member_provider.dart';
+import 'package:application_new/domain/travel/travel_repository.dart';
 import 'package:application_new/feature/travel_create/page/travel_companion_type_form.dart';
 import 'package:application_new/feature/travel_create/page/travel_date_form.dart';
 import 'package:application_new/feature/travel_create/page/travel_form_page.dart';
@@ -53,8 +55,14 @@ class _TravelPlanHomePageState extends ConsumerState<TravelPlanHomePage> {
         TravelFormPage(
           initialState: TravelCreateState(name: travel.name),
           canSubmit: (state) => travel.name != state.name,
-          onSubmit: (state) {
-            print(state.name);
+          onSubmit: (state) async {
+            final navigator = Navigator.of(context);
+
+            await ref
+                .read(TravelPlanProvider(travel.id).notifier)
+                .editTravel(name: state.name);
+
+            navigator.pop();
           },
           pageSize: 1,
           buildPages: (bottomViewBuilder) => [
@@ -72,10 +80,17 @@ class _TravelPlanHomePageState extends ConsumerState<TravelPlanHomePage> {
         TravelFormPage(
           initialState: TravelCreateState(
               startedOn: travel.startedOn, endedOn: travel.endedOn),
-          canSubmit: (state) => state.startedOn != travel.startedOn &&
-                state.endedOn != travel.endedOn,
-          onSubmit: (state) {
-            print(state);
+          canSubmit: (state) =>
+              state.startedOn != travel.startedOn &&
+              state.endedOn != travel.endedOn,
+          onSubmit: (state)  async {
+            final navigator = Navigator.of(context);
+
+            await ref
+                .read(TravelPlanProvider(travel.id).notifier)
+                .editTravel(startedOn: state.startedOn, endedOn: state.endedOn);
+
+            navigator.pop();
           },
           pageSize: 1,
           buildPages: (bottomViewBuilder) => [
@@ -91,20 +106,27 @@ class _TravelPlanHomePageState extends ConsumerState<TravelPlanHomePage> {
         showDragHandle: false,
         context,
         TravelFormPage(
-          initialState: TravelCreateState(
-              companionTypes: travel.companionTypes),
-          canSubmit: (state) => !listEquals(state.companionTypes, travel.companionTypes),
-          onSubmit: (state) {
-            print(state);
+          initialState:
+              TravelCreateState(companionTypes: travel.companionTypes),
+          canSubmit: (state) =>
+              !listEquals(state.companionTypes, travel.companionTypes),
+          onSubmit: (state)  async {
+            final navigator = Navigator.of(context);
+
+            await ref
+                .read(TravelPlanProvider(travel.id).notifier)
+                .editTravel(companionTypes: state.companionTypes);
+
+            navigator.pop();
           },
           pageSize: 1,
           buildPages: (bottomViewBuilder) => [
-            TravelCompanionTypeForm(pageIndex: 0, bottomViewBuilder: bottomViewBuilder)
+            TravelCompanionTypeForm(
+                pageIndex: 0, bottomViewBuilder: bottomViewBuilder)
           ],
         ),
       ),
     );
-
 
     final editMotivationTypeAction = ActionSheetItem(
       title: ref.watch(translationServiceProvider).from('Edit motivation type'),
@@ -112,16 +134,23 @@ class _TravelPlanHomePageState extends ConsumerState<TravelPlanHomePage> {
         showDragHandle: false,
         context,
         TravelFormPage(
-          initialState: TravelCreateState(
-              motivationTypes: travel.motivationTypes),
-          canSubmit: (state) => !setEquals(state.motivationTypes.toSet(),
-              travel.motivationTypes.toSet()),
-          onSubmit: (state) {
-            print(state);
+          initialState:
+              TravelCreateState(motivationTypes: travel.motivationTypes),
+          canSubmit: (state) => !setEquals(
+              state.motivationTypes.toSet(), travel.motivationTypes.toSet()),
+          onSubmit: (state) async {
+            final navigator = Navigator.of(context);
+
+            await ref
+                .read(TravelPlanProvider(travel.id).notifier)
+                .editTravel(motivationTypes: state.motivationTypes);
+
+            navigator.pop();
           },
           pageSize: 1,
           buildPages: (bottomViewBuilder) => [
-            TravelMotivationTypeForm(pageIndex: 0, bottomViewBuilder: bottomViewBuilder)
+            TravelMotivationTypeForm(
+                pageIndex: 0, bottomViewBuilder: bottomViewBuilder)
           ],
         ),
       ),

--- a/application/lib/feature/travel_plan/provider/travel_plan_provider.dart
+++ b/application/lib/feature/travel_plan/provider/travel_plan_provider.dart
@@ -1,6 +1,9 @@
 import 'package:application_new/common/http/http_service_provider.dart';
+import 'package:application_new/common/loading/async_loading_provider.dart';
 import 'package:application_new/common/util/iterable_util.dart';
 import 'package:application_new/domain/geography/geography_model.dart';
+import 'package:application_new/domain/travel/travel_model.dart';
+import 'package:application_new/domain/travel/travel_repository.dart';
 import 'package:application_new/feature/travel_plan/provider/travel_plan_state.dart';
 import 'package:application_new/domain/travel/travel_provider.dart';
 
@@ -10,26 +13,56 @@ part 'travel_plan_provider.g.dart';
 
 @riverpod
 class TravelPlan extends _$TravelPlan {
-
   @override
   FutureOr<TravelPlanState> build(int travelId) async {
     final travel = await ref.watch(travelProvider(travelId).future);
 
     final cities = await _fetchCities(travelId);
 
-    return TravelPlanState(travel: travel, cities: cities, selectedCity: cities.first);
+    return TravelPlanState(
+        travel: travel, cities: cities, selectedCity: cities.first);
   }
 
   Future<List<CityModel>> _fetchCities(int travelId) async {
+    final response =
+        await ref.read(httpServiceProvider).get('/travels/$travelId/cities');
+    return List.of(response['cities'])
+        .map((json) => CityModel.fromJson(json))
+        .toList();
+  }
 
-    final response = await ref.read(httpServiceProvider).get('/travels/$travelId/cities');
-    return List.of(response['cities']).map((json) => CityModel.fromJson(json)).toList();
+  Future<void> editTravel({
+    String? name,
+    DateTime? startedOn,
+    DateTime? endedOn,
+    List<TravelCompanionType>? companionTypes,
+    List<TravelMotivationType>? motivationTypes,
+    List<CityModel>? cities,
+  }) async {
+    final prevState = state.value;
+    if (prevState == null) return;
 
+    final loadingNotifier = ref.read(asyncLoadingProvider.notifier);
+
+    final updatedTravel = await loadingNotifier
+        .guard(() => ref.read(travelRepositoryProvider).update(
+              travelId,
+              name: name,
+              startedOn: startedOn,
+              endedOn: endedOn,
+              companionTypes: companionTypes,
+              motivationTypes: motivationTypes,
+              cities: cities,
+            ));
+
+    state = AsyncValue.data(prevState.copyWith(travel: updatedTravel));
   }
 
   void changePage(int pageIndex) {
     final prevState = state.value;
-    if (prevState == null || !IterableUtil.isIndexInRange(pageIndex, end: 4)) return;
+    if (prevState == null || !IterableUtil.isIndexInRange(pageIndex, end: 4)) {
+      return;
+    }
 
     state = AsyncValue.data(prevState.copyWith(pageIndex: pageIndex));
   }
@@ -39,7 +72,5 @@ class TravelPlan extends _$TravelPlan {
     if (prevState == null) return;
 
     state = AsyncValue.data(prevState.copyWith(selectedCity: city));
-
   }
-
 }

--- a/application/lib/feature/travel_plan/provider/travel_plan_provider.g.dart
+++ b/application/lib/feature/travel_plan/provider/travel_plan_provider.g.dart
@@ -6,7 +6,7 @@ part of 'travel_plan_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$travelPlanHash() => r'fd6394e709b225f4d3bbdb16b0cb7479e2250683';
+String _$travelPlanHash() => r'1acd7b137dcabd6048ddb0de4cf37546fdc967d2';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/application/lib/shared/component/action_sheet.dart
+++ b/application/lib/shared/component/action_sheet.dart
@@ -34,6 +34,7 @@ class ActionSheet extends ConsumerWidget {
         ActionSheetGroupItem(items: [
           ActionSheetItem(
               title: tr.from('Close'),
+              titleColor: Theme.of(context).colorScheme.error,
               onAction: () {})
         ]),
         SizedBox(height: MediaQuery.of(context).padding.bottom),

--- a/application/lib/shared/component/action_sheet_item.dart
+++ b/application/lib/shared/component/action_sheet_item.dart
@@ -22,8 +22,8 @@ class ActionSheetItem extends ConsumerWidget {
         style: TextStyle(color: titleColor, fontWeight: FontWeight.w600),
       )),
       onTap: () {
-        onAction();
         Navigator.of(context).pop();
+        onAction();
       },
     );
   }

--- a/application/lib/shared/component/paged_form_bottom_control_view.dart
+++ b/application/lib/shared/component/paged_form_bottom_control_view.dart
@@ -46,19 +46,19 @@ class PagedFormBottomControlView extends ConsumerWidget {
     final tr = ref.watch(translationServiceProvider);
     return SafeBottomView(
         child: Row(children: [
-      if (hasPreviousPage)
+      if (hasPreviousPage) ...[
         Expanded(
             child: OutlinedButton(
                 onPressed: hasPreviousPage ? _previousPage : null,
                 child: Text(tr.from('Previous')))),
-      if (hasPreviousPage && hasNextPage) const SizedBox(width: 8.0),
-        Expanded(
-            child: FilledButton(
-                onPressed: hasNextPage
-                    ? (isInputted ? _nextPage : null)
-                    : (canSubmit && isInputted ? onSubmit : null),
-                child:
-                    Text(hasNextPage ? tr.from('Next') : tr.from('Submit')))),
+        const SizedBox(width: 8.0),
+      ],
+      Expanded(
+          child: FilledButton(
+              onPressed: hasNextPage
+                  ? (isInputted ? _nextPage : null)
+                  : (canSubmit && isInputted ? onSubmit : null),
+              child: Text(hasNextPage ? tr.from('Next') : tr.from('Submit')))),
     ]));
   }
 

--- a/application/lib/shared/component/paged_form_bottom_control_view.dart
+++ b/application/lib/shared/component/paged_form_bottom_control_view.dart
@@ -4,59 +4,70 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 
+typedef PagedFormBottomControlViewBuilder = PagedFormBottomControlView Function(
+    {required int pageIndex, required bool isInputted});
+
 class PagedFormBottomControlView extends ConsumerWidget {
   final PageController pageController;
 
-  final bool isInputted;
+  final bool canSubmit, isInputted;
 
   final bool hasPreviousPage, hasNextPage;
-  final VoidCallback? onPreviousPage, onNextPage;
 
   final VoidCallback? onSubmit;
 
   const PagedFormBottomControlView(
       {super.key,
+      required this.canSubmit,
       required this.isInputted,
-      required PageController controller,
-      this.onPreviousPage,
-      this.onNextPage,
-      this.onSubmit,
-      this.hasNextPage = true,
-      this.hasPreviousPage = true})
-      : pageController = controller;
+      required int pageIndex,
+      required int pageSize,
+      required this.pageController,
+      this.onSubmit})
+      : hasNextPage = pageIndex + 1 < pageSize,
+        hasPreviousPage = pageIndex > 0;
 
+  static PagedFormBottomControlViewBuilder create(PageController pageController,
+      {required int pageSize,
+      required bool canSubmit,
+      required VoidCallback onSubmit}) {
+    return ({required int pageIndex, required bool isInputted}) =>
+        PagedFormBottomControlView(
+            pageController: pageController,
+            pageIndex: pageIndex,
+            pageSize: pageSize,
+            onSubmit: onSubmit,
+            canSubmit: canSubmit,
+            isInputted: isInputted);
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tr = ref.watch(translationServiceProvider);
-
     return SafeBottomView(
         child: Row(children: [
-      Expanded(
-          child: OutlinedButton(
-              onPressed: hasPreviousPage ? _previousPage : null,
-              child: Text(tr.from('Previous')))),
-      const SizedBox(width: 8.0),
-      Expanded(
-          child: FilledButton(
-              onPressed: isInputted ? _nextPage : null,
-              child: Text(hasNextPage ? tr.from('Next') : tr.from('Submit')))),
+      if (hasPreviousPage)
+        Expanded(
+            child: OutlinedButton(
+                onPressed: hasPreviousPage ? _previousPage : null,
+                child: Text(tr.from('Previous')))),
+      if (hasPreviousPage && hasNextPage) const SizedBox(width: 8.0),
+        Expanded(
+            child: FilledButton(
+                onPressed: hasNextPage
+                    ? (isInputted ? _nextPage : null)
+                    : (canSubmit ? onSubmit : null),
+                child:
+                    Text(hasNextPage ? tr.from('Next') : tr.from('Submit')))),
     ]));
   }
-  
+
   void _previousPage() {
-    onPreviousPage?.call();
     pageController.previousPage(
         duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
   }
 
   void _nextPage() {
-    if (!hasNextPage) {
-      onSubmit?.call();
-      return;
-    }
-
-    onNextPage?.call();
     pageController.nextPage(
         duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
   }

--- a/application/lib/shared/component/paged_form_bottom_control_view.dart
+++ b/application/lib/shared/component/paged_form_bottom_control_view.dart
@@ -56,7 +56,7 @@ class PagedFormBottomControlView extends ConsumerWidget {
             child: FilledButton(
                 onPressed: hasNextPage
                     ? (isInputted ? _nextPage : null)
-                    : (canSubmit ? onSubmit : null),
+                    : (canSubmit && isInputted ? onSubmit : null),
                 child:
                     Text(hasNextPage ? tr.from('Next') : tr.from('Submit')))),
     ]));

--- a/application/lib/shared/component/show_modal_content_sheet.dart
+++ b/application/lib/shared/component/show_modal_content_sheet.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 Future<T?> showModalContentSheet<T>(
-    BuildContext context, Widget content) async {
+    BuildContext context, Widget content, { bool? showDragHandle }) async {
   final ColorScheme(:surface) = Theme.of(context).colorScheme;
 
   return showModalBottomSheet<T>(
@@ -9,7 +9,7 @@ Future<T?> showModalContentSheet<T>(
       backgroundColor: surface,
       isScrollControlled: true,
       useSafeArea: true,
-      showDragHandle: true,
+      showDragHandle: showDragHandle ?? true,
       clipBehavior: Clip.hardEdge,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(8.0)),


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> Ex. close #이슈 번호, #이슈 번호

#10 

## 📝 작업 내용
> 작업한 내용을 간략히 설명해 주세요.

- [x] 여행 수정 UI 구현

  - 여행 생성 UI를 `TravelFormPage`로 추상화, **여행 정보 수정에 재사용**

    - 고차 함수로 외부에서 입력할 폼, 제출 시 동작을 정의하도록 개선

    - 페이지 컨트롤의 공통 속성(페이지 수, 컨트롤러 등)을 클로저(Closure)로 지정하는 `create()` 정적 팩토리 함수 구현

  - `TravelFormPage` 호출 시 초기값을 지정할 수 있도록 구현

- [x] 여행 수정 API와 연동

  - 수정할 항목을 액션 시트로 선택하게끔 구현

  - 액션 시트 선택 시 폼 UI가 표시되고, 제출 시 수정 API를 호출


## ✅ 작업 결과
> 작업 내용 Notion 링크, 혹은 이미지를 첨부해 주세요.

![Simulator Screen Recording - iPhone 15 Pro Max - 2025-01-15 at 14 15 16](https://github.com/user-attachments/assets/bb1618a6-f50e-4cae-9c88-b9aca78d791b)

## 💬 추가 사항 (선택)
> 추가로 기재할 사항이 있으면 기재해 주세요.

### 페이지 컨트롤 뷰 공통 속성 처리하기
```dart
class PagedFormBottomControlView extends ConsumerWidget {
  final PageController pageController;

  final bool canSubmit, isInputted;

  final bool hasPreviousPage, hasNextPage;

  final VoidCallback? onSubmit;

  const PagedFormBottomControlView(
      {super.key,
      required this.canSubmit,
      required this.isInputted,
      required int pageIndex,
      required int pageSize,
      required this.pageController,
      this.onSubmit})
      : hasNextPage = pageIndex + 1 < pageSize,
        hasPreviousPage = pageIndex > 0;

}
```
`PagedFormBottomControlView`는 페이지 이동 및 결과 제출을 처리하는 위젯으로, 동작을 위해서 페이지 정보 및 컨트롤러가 필요하다.  


```dart
typedef PagedFormBottomControlViewBuilder = PagedFormBottomControlView Function(
    {required int pageIndex, required bool isInputted});

class PagedFormBottomControlView extends ConsumerWidget {
  final VoidCallback? onSubmit;
  // ...
  static PagedFormBottomControlViewBuilder create(PageController pageController,
      {required int pageSize,
      required bool canSubmit,
      required VoidCallback onSubmit}) {
    return ({required int pageIndex, required bool isInputted}) =>
        PagedFormBottomControlView(
            pageController: pageController,
            pageIndex: pageIndex,
            pageSize: pageSize,
            onSubmit: onSubmit,
            canSubmit: canSubmit,
            isInputted: isInputted);
  }
}
```
여러 `Form`을 묶은 페이지에서 해당 정보를 정의하고, 자식 `Form`들에게 일일이 파라미터로 넘겨줘야 한다.

이를 해결하기 위해, **공통 속성이 정의된 `Builder` 함수를 반환**하도록 구현했다. 
- `create` 함수를 상위 페이지에서 호출해, 중복된 정보를 미리 정의한다. 그리고 하위 `Form`은 반환된 `Builder` 함수에 개별 정보를 지정해 사용한다.
- 플러터 또한 클로저와 렉시컬 스코프가 구현되어 있으므로 `Builder` 안에서 `create`의 파라미터 목록에 접근할 수 있다.

```dart

class TravelNameForm extends ConsumerWidget {
  final int pageIndex;
  final PagedFormBottomControlViewBuilder bottomViewBuilder;

  const TravelNameForm(
      {super.key, required this.pageIndex, required this.bottomViewBuilder});

  @override
  Widget build(BuildContext context, WidgetRef ref) {
    // ...
    return Scaffold(
      bottomNavigationBar: widget.bottomViewBuilder(
          isInputted: name?.isNotEmpty ?? defaultName?.isNotEmpty ?? false,
          pageIndex: widget.pageIndex),
    );
  }
}
```

위 함수를 사용하면, 하위 `Form`의 코드를 깔끔히 유지할 수 있다.

---

### Flutter의 컬렉션 동등성 비교

```dart
import 'package:flutter/foundation.dart';

var list1 = <int>[1, 2, 3];
var list2 = <int>[1, 2, 3];

assert(listEquals(list1, list2) == true);
```

여러 언어가 그렇듯이, Flutter에서도 컬렉션(배열, 리스트 등)은 주소 값을 기준으로 동등(`==`) 비교된다. 만약 원소의 값을 기준으로 비교하고 싶으면, `listEquals()` 혹은 `setEquals()` 함수를 사용하면 된다.

```dart
import 'package:flutter/foundation.dart';

var list1 = <int>[1, 2, 3];
var list2 = <int>[3, 2, 1];

assert(listEquals(list1, list2) == false);
```

`listEquals()` 는 리스트 원소의 값, 순서를 파악해 동등 비교하며, `setEquals()`는 원소의 값만 비교한다. 상황에 맞게 사용하면 된다.

> https://stackoverflow.com/questions/10404516/how-can-i-compare-lists-for-equality-in-dart




